### PR TITLE
unwrap method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+cmake-build-*/
 build
 c-api
 html

--- a/examples/gcd.cc
+++ b/examples/gcd.cc
@@ -5,15 +5,6 @@
 
 using namespace wasmtime;
 
-template<typename T, typename E>
-T unwrap(Result<T, E> result) {
-  if (result) {
-    return result.ok();
-  }
-  std::cerr << "error: " << result.err().message() << "\n";
-  std::abort();
-}
-
 std::string readFile(const char* name) {
   std::ifstream watFile;
   watFile.open(name);
@@ -28,12 +19,12 @@ int main() {
   // can instantiate it.
   Engine engine;
   Store store(engine);
-  auto module = unwrap(Module::compile(engine, readFile("examples/gcd.wat")));
-  auto instance = unwrap(Instance::create(store, module, {}));
+  auto module = Module::compile(engine, readFile("examples/gcd.wat")).unwrap();
+  auto instance = Instance::create(store, module, {}).unwrap();
 
   // Invoke `gcd` export
   auto gcd = std::get<Func>(*instance.get(store, "gcd"));
-  auto results = unwrap(gcd.call(store, {6, 27}));
+  auto results = gcd.call(store, {6, 27}).unwrap();
 
   std::cout << "gcd(6, 27) = " << results[0].i32() << "\n";
 }

--- a/examples/hello.cc
+++ b/examples/hello.cc
@@ -5,15 +5,6 @@
 
 using namespace wasmtime;
 
-template<typename T, typename E>
-T unwrap(Result<T, E> result) {
-  if (result) {
-    return result.ok();
-  }
-  std::cerr << "error: " << result.err().message() << "\n";
-  std::abort();
-}
-
 std::string readFile(const char* name) {
   std::ifstream watFile;
   watFile.open(name);
@@ -29,7 +20,7 @@ int main() {
   // default like this is here.
   std::cout << "Compiling module\n";
   Engine engine;
-  auto module = unwrap(Module::compile(engine, readFile("examples/hello.wat")));
+  auto module = Module::compile(engine, readFile("examples/hello.wat")).unwrap();
 
   // After a module is compiled we create a `Store` which will contain
   // instantiated modules and other items like host functions. A Store
@@ -56,7 +47,7 @@ int main() {
   // phase, pairing together a compiled module as well as a set of imports.
   // Note that this is where the wasm `start` function, if any, would run.
   std::cout << "Instantiating module...\n";
-  auto instance = unwrap(Instance::create(store, module, {host_func}));
+  auto instance = Instance::create(store, module, {host_func}).unwrap();
 
   // Next we poke around a bit to extract the `run` function from the module.
   std::cout << "Extracting export...\n";
@@ -64,7 +55,7 @@ int main() {
 
   // And last but not least we can call it!
   std::cout << "Calling export...\n";
-  unwrap(run.call(store, {}));
+  run.call(store, {}).unwrap();
 
   std::cout << "Done\n";
 }

--- a/examples/interrupt.cc
+++ b/examples/interrupt.cc
@@ -27,15 +27,6 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 using namespace wasmtime;
 
-template<typename T, typename E>
-T unwrap(Result<T, E> result) {
-  if (result) {
-    return result.ok();
-  }
-  std::cerr << "error: " << result.err().message() << "\n";
-  std::abort();
-}
-
 std::string readFile(const char* name) {
   std::ifstream watFile;
   watFile.open(name);
@@ -55,8 +46,8 @@ int main() {
 
   // Compile and instantiate a small example with an infinite loop.
   auto wat = readFile("examples/interrupt.wat");
-  Module module = unwrap(Module::compile(engine, wat));
-  Instance instance = unwrap(Instance::create(store, module, {}));
+  Module module = Module::compile(engine, wat).unwrap();
+  Instance instance = Instance::create(store, module, {}).unwrap();
   Func run = std::get<Func>(*instance.get(store, "run"));
 
   // Spin up a thread to send us an interrupt in a second

--- a/examples/linking.cc
+++ b/examples/linking.cc
@@ -31,8 +31,8 @@ int main() {
   std::string linking2_wat = readFile("examples/linking2.wat");
 
   // Compile our two modules
-  Module linking1_module = unwrap(Module::compile(engine, linking1_wat));
-  Module linking2_module = unwrap(Module::compile(engine, linking2_wat));
+  Module linking1_module = Module::compile(engine, linking1_wat).unwrap();
+  Module linking2_module = Module::compile(engine, linking2_wat).unwrap();
 
   // Configure WASI and store it within our `wasmtime_store_t`
   WasiConfig wasi;
@@ -41,20 +41,20 @@ int main() {
   wasi.inherit_stdin();
   wasi.inherit_stdout();
   wasi.inherit_stderr();
-  unwrap(store.context().set_wasi(std::move(wasi)));
+  store.context().set_wasi(std::move(wasi)).unwrap();
 
   // Create our linker which will be linking our modules together, and then add
   // our WASI instance to it.
   Linker linker(engine);
-  unwrap(linker.define_wasi());
+  linker.define_wasi().unwrap();
 
   // Instantiate our first module which only uses WASI, then register that
   // instance with the linker since the next linking will use it.
-  Instance linking2 = unwrap(linker.instantiate(store, linking2_module));
-  unwrap(linker.define_instance(store, "linking2", linking2));
+  Instance linking2 = linker.instantiate(store, linking2_module).unwrap();
+  linker.define_instance(store, "linking2", linking2).unwrap();
 
   // And with that we can perform the final link and the execute the module.
-  Instance linking1 = unwrap(linker.instantiate(store, linking1_module));
+  Instance linking1 = linker.instantiate(store, linking1_module).unwrap();
   Func f = std::get<Func>(*linking1.get(store, "run"));
-  unwrap(f.call(store, {}));
+  f.call(store, {}).unwrap();
 }

--- a/examples/memory.cc
+++ b/examples/memory.cc
@@ -7,15 +7,6 @@
 
 using namespace wasmtime;
 
-template<typename T, typename E>
-T unwrap(Result<T, E> result) {
-  if (result) {
-    return result.ok();
-  }
-  std::cerr << "error: " << result.err().message() << "\n";
-  std::abort();
-}
-
 std::string readFile(const char* name) {
   std::ifstream watFile;
   watFile.open(name);
@@ -28,9 +19,9 @@ int main() {
   // Create our `store` context and then compile a module and create an
   // instance from the compiled module all in one go.
   Engine engine;
-  Module module = unwrap(Module::compile(engine, readFile("examples/memory.wat")));
+  Module module = Module::compile(engine, readFile("examples/memory.wat")).unwrap();
   Store store(engine);
-  Instance instance = unwrap(Instance::create(store, module, {}));
+  Instance instance = Instance::create(store, module, {}).unwrap();
 
   // load_fn up our exports from the instance
   auto memory = std::get<Memory>(*instance.get(store, "memory"));
@@ -46,32 +37,32 @@ int main() {
   assert(data[0x1000] == 1);
   assert(data[0x1003] == 4);
 
-  assert(unwrap(size.call(store, {}))[0].i32() == 2);
-  assert(unwrap(load_fn.call(store, {0}))[0].i32() == 0);
-  assert(unwrap(load_fn.call(store, {0x1000}))[0].i32() == 1);
-  assert(unwrap(load_fn.call(store, {0x1003}))[0].i32() == 4);
-  assert(unwrap(load_fn.call(store, {0x1ffff}))[0].i32() == 0);
+  assert(size.call(store, {}).unwrap()[0].i32() == 2);
+  assert(load_fn.call(store, {0}).unwrap()[0].i32() == 0);
+  assert(load_fn.call(store, {0x1000}).unwrap()[0].i32() == 1);
+  assert(load_fn.call(store, {0x1003}).unwrap()[0].i32() == 4);
+  assert(load_fn.call(store, {0x1ffff}).unwrap()[0].i32() == 0);
   load_fn.call(store, {0x20000}).err(); // out of bounds trap
 
   std::cout << "Mutating memory...\n";
   memory.data(store)[0x1003] = 5;
 
-  unwrap(store_fn.call(store, {0x1002, 6}));
+  store_fn.call(store, {0x1002, 6}).unwrap();
   store_fn.call(store, {0x20000, 0}).err(); // out of bounds trap
 
   assert(memory.data(store)[0x1002] == 6);
   assert(memory.data(store)[0x1003] == 5);
-  assert(unwrap(load_fn.call(store, {0x1002}))[0].i32() == 6);
-  assert(unwrap(load_fn.call(store, {0x1003}))[0].i32() == 5);
+  assert(load_fn.call(store, {0x1002}).unwrap()[0].i32() == 6);
+  assert(load_fn.call(store, {0x1003}).unwrap()[0].i32() == 5);
 
   // Grow memory.
   std::cout << "Growing memory...\n";
-  unwrap(memory.grow(store, 1));
+  memory.grow(store, 1).unwrap();
   assert(memory.size(store) == 3);
   assert(memory.data(store).size() == 0x30000);
 
-  assert(unwrap(load_fn.call(store, {0x20000}))[0].i32() == 0);
-  unwrap(store_fn.call(store, {0x20000, 0}));
+  assert(load_fn.call(store, {0x20000}).unwrap()[0].i32() == 0);
+  store_fn.call(store, {0x20000, 0}).unwrap();
   load_fn.call(store, {0x30000}).err();
   store_fn.call(store, {0x30000, 0}).err();
 
@@ -80,7 +71,7 @@ int main() {
 
   std::cout << "Creating stand-alone memory...\n";
   MemoryType ty(Limits(5, 5));
-  Memory memory2 = unwrap(Memory::create(store, ty));
+  Memory memory2 = Memory::create(store, ty).unwrap();
   assert(memory2.size(store) == 5);
   memory2.grow(store, 1).err();
   memory2.grow(store, 0).ok();

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -105,6 +105,15 @@ public:
   T &&ok() { return std::get<T>(std::move(data)); }
   /// \brief Returns the success, if present, aborts if this is an error.
   const T &&ok() const { return std::get<T>(std::move(data)); }
+
+  /// \brief Returns the success, if present, aborts if this is an error.
+  T unwrap() {
+    if (*this) {
+      return this->ok();
+    }
+    std::cerr << "error: " << this->err().message() << "\n";
+    std::abort();
+  }
 };
 
 /// \brief Strategies passed to `Config::strategy`


### PR DESCRIPTION
Moved unwrap method in Result class to make it more C++ like and also consistent with Rust `.unwrap()` function