### PR TITLE
Use C++17 instead of C++20 by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,11 @@ jobs:
           config: Debug
         - os: windows-latest
           config: Release
+
+        # C++20
+        - os: ubuntu-latest
+          config: Debug
+          args: -DCMAKE_CXX_COMPILER=clang++ -DCXX_STANDARD_20=YES
     steps:
     - uses: actions/checkout@v2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.10)
 project(Wasmtime VERSION 0.27.0)
 
+option(CXX_STANDARD_20 "Use C++20" OFF)
+message(STATUS "CXX_STANDARD_20       ${CXX_STANDARD_20}")
+
+if (CXX_STANDARD_20)
 set(CMAKE_CXX_STANDARD 20)
+else()
+set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 option(ENABLE_CODE_ANALYSIS "Run code analysis" OFF)

--- a/examples/memory.cc
+++ b/examples/memory.cc
@@ -31,8 +31,8 @@ int main() {
 
   std::cout << "Checking memory...\n";
   assert(memory.size(store) == 2);
-  auto data = memory.data(store);
-  assert(data.size() == 0x20000);
+  auto *data = memory.data_ptr(store);
+  assert(memory.data_size(store) == 0x20000);
   assert(data[0] == 0);
   assert(data[0x1000] == 1);
   assert(data[0x1003] == 4);
@@ -45,13 +45,13 @@ int main() {
   load_fn.call(store, {0x20000}).err(); // out of bounds trap
 
   std::cout << "Mutating memory...\n";
-  memory.data(store)[0x1003] = 5;
+  memory.data_ptr(store)[0x1003] = 5;
 
   store_fn.call(store, {0x1002, 6}).unwrap();
   store_fn.call(store, {0x20000, 0}).err(); // out of bounds trap
 
-  assert(memory.data(store)[0x1002] == 6);
-  assert(memory.data(store)[0x1003] == 5);
+  assert(memory.data_ptr(store)[0x1002] == 6);
+  assert(memory.data_ptr(store)[0x1003] == 5);
   assert(load_fn.call(store, {0x1002}).unwrap()[0].i32() == 6);
   assert(load_fn.call(store, {0x1003}).unwrap()[0].i32() == 5);
 
@@ -59,7 +59,7 @@ int main() {
   std::cout << "Growing memory...\n";
   memory.grow(store, 1).unwrap();
   assert(memory.size(store) == 3);
-  assert(memory.data(store).size() == 0x30000);
+  assert(memory.data_size(store) == 0x30000);
 
   assert(load_fn.call(store, {0x20000}).unwrap()[0].i32() == 0);
   store_fn.call(store, {0x20000, 0}).unwrap();

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -390,10 +390,15 @@ class Limits {
 
 public:
   /// \brief Configures a minimum limit and no maximum limit.
-  explicit Limits(uint32_t min)
-      : raw({.min = min, .max = wasm_limits_max_default}) {}
+  explicit Limits(uint32_t min) : raw{} {
+    raw.min = min;
+    raw.max = wasm_limits_max_default;
+  }
   /// \brief Configures both a minimum and a maximum limit.
-  Limits(uint32_t min, uint32_t max) : raw({.min = min, .max = max}) {}
+  Limits(uint32_t min, uint32_t max) : raw{} {
+    raw.min = min;
+    raw.max = max;
+  }
   /// \brief Creates limits from the raw underlying C API.
   Limits(const wasm_limits_t *limits) : raw(*limits) {}
 
@@ -875,7 +880,10 @@ public:
 
   public:
     /// Creates an empty list
-    List() : list({.size = 0, .data = nullptr}) {}
+    List() : list{} {
+      list.size = 0;
+      list.data = nullptr;
+    }
     List(const List &other) = delete;
     /// Moves another list into this one.
     List(List &&other) noexcept : list(other.list) { other.list.size = 0; }
@@ -944,7 +952,10 @@ public:
 
   public:
     /// Creates an empty list
-    List() : list({.size = 0, .data = nullptr}) {}
+    List() : list{} {
+      list.size = 0;
+      list.data = nullptr;
+    }
     List(const List &other) = delete;
     /// Moves another list into this one.
     List(List &&other) noexcept : list(other.list) { other.list.size = 0; }
@@ -1800,21 +1811,36 @@ class Val {
 
   wasmtime_val_t val;
 
-  Val() : val({.kind = WASMTIME_I32, .of = {.i32 = 0}}) {}
+  Val() : val{} {
+    val.kind = WASMTIME_I32;
+    val.of.i32 = 0;
+  }
   Val(wasmtime_val_t val) : val(val) {}
 
 public:
   /// Creates a new `i32` WebAssembly value.
-  Val(int32_t i32) : val({.kind = WASMTIME_I32, .of = {.i32 = i32}}) {}
+  Val(int32_t i32) : val{} {
+    val.kind = WASMTIME_I32;
+    val.of.i32 = i32;
+  }
   /// Creates a new `i64` WebAssembly value.
-  Val(int64_t i64) : val({.kind = WASMTIME_I64, .of = {.i64 = i64}}) {}
+  Val(int64_t i64) : val{} {
+    val.kind = WASMTIME_I64;
+    val.of.i64 = i64;
+  }
   /// Creates a new `f32` WebAssembly value.
-  Val(float f32) : val({.kind = WASMTIME_F32, .of = {.f32 = f32}}) {}
+  Val(float f32) : val{} {
+    val.kind = WASMTIME_F32;
+    val.of.f32 = f32;
+  }
   /// Creates a new `f64` WebAssembly value.
-  Val(double f64) : val({.kind = WASMTIME_F64, .of = {.f64 = f64}}) {}
+  Val(double f64) : val{} {
+    val.kind = WASMTIME_F64;
+    val.of.f64 = f64;
+  }
   /// Creates a new `v128` WebAssembly value.
-  Val(const wasmtime_v128 &v128)
-      : val({.kind = WASMTIME_V128, .of = {.i32 = 0}}) {
+  Val(const wasmtime_v128 &v128) : val{} {
+    val.kind = WASMTIME_V128;
     memcpy(&val.of.v128[0], &v128[0], sizeof(wasmtime_v128));
   }
   /// Creates a new `funcref` WebAssembly value.
@@ -1822,23 +1848,21 @@ public:
   /// Creates a new `funcref` WebAssembly value which is not `ref.null func`.
   Val(Func func);
   /// Creates a new `externref` value.
-  Val(std::optional<ExternRef> ptr)
-      : val({.kind = WASMTIME_EXTERNREF, .of = {.externref = nullptr}}) {
+  Val(std::optional<ExternRef> ptr) : val{} {
+    val.kind = WASMTIME_EXTERNREF;
     if (ptr) {
       val.of.externref = ptr->ptr.release();
+    } else {
+      val.of.externref = nullptr;
     }
   }
   /// Creates a new `externref` WebAssembly value which is not `ref.null
   /// extern`.
   Val(ExternRef ptr);
   /// Copies the contents of another value into this one.
-  Val(const Val &other) : val({.kind = WASMTIME_I32, .of = {.i32 = 0}}) {
-    wasmtime_val_copy(&val, &other.val);
-  }
+  Val(const Val &other) : val{} { wasmtime_val_copy(&val, &other.val); }
   /// Moves the resources from another value into this one.
-  Val(Val &&other) noexcept : val({.kind = WASMTIME_I32, .of = {.i32 = 0}}) {
-    std::swap(val, other.val);
-  }
+  Val(Val &&other) noexcept : val{} { std::swap(val, other.val); }
 
   ~Val() {
     if (val.kind == WASMTIME_EXTERNREF && val.of.externref != nullptr) {
@@ -2079,7 +2103,7 @@ public:
    * need to be written to.
    */
   template <typename F>
-  Func(Store::Context cx, const FuncType &ty, F f) : func({}) {
+  Func(Store::Context cx, const FuncType &ty, F f) : func{} {
     wasmtime_func_new(cx.ptr, ty.ptr.get(), raw_callback<F>,
                       std::make_unique<F>(f).release(), raw_finalize<F>, &func);
   }
@@ -2135,11 +2159,13 @@ public:
   }
 };
 
-Val::Val(std::optional<Func> func)
-    : val({.kind = WASMTIME_FUNCREF,
-           .of = {.funcref = {.store_id = 0, .index = 0}}}) {
+Val::Val(std::optional<Func> func) : val{} {
+  val.kind = WASMTIME_FUNCREF;
   if (func) {
     val.of.funcref = (*func).func;
+  } else {
+    val.of.funcref.store_id = 0;
+    val.of.funcref.index = 0;
   }
 }
 

--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -242,7 +242,7 @@ TEST(Memory, Smoke) {
   Memory m = unwrap(Memory::create(store, MemoryType(Limits(1))));
   EXPECT_EQ(m.size(store), 1);
   EXPECT_EQ(unwrap(m.grow(store, 1)), 1);
-  EXPECT_EQ(m.data(store).size(), 2 << 16);
+  EXPECT_EQ(m.data_size(store), 2 << 16);
   EXPECT_EQ(m.type(store)->limits().min(), 1);
 }
 


### PR DESCRIPTION
This commit removes the dependence on `std::span` which means that this
header can be used with C++17. Various methods that took a `std::span`
now have overloads that take a pointer/length as well as a `const
vector<T>&`. Methods that give a `std::span` now have separate accessor
methods for the pointer and the length.

The hardest one to migrate was the arguments provided to function
closures, and for that purpose a local `Span` class was created.

In all cases support for C++20 is in theory detected at compile time and
`std::span` support is enabled (methods are added back, etc). The
`wasmtime::Span` class should be auto-convertible to `std::span` in
theory (if I understand C++ correctly).