### PR TITLE
Implement support for the memory64 proposal 

### DIFF
--- a/examples/memory.cc
+++ b/examples/memory.cc
@@ -70,7 +70,7 @@ int main() {
   memory.grow(store, 0).ok();
 
   std::cout << "Creating stand-alone memory...\n";
-  MemoryType ty(Limits(5, 5));
+  MemoryType ty(5, 5);
   Memory memory2 = Memory::create(store, ty).unwrap();
   assert(memory2.size(store) == 5);
   memory2.grow(store, 1).err();

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -738,7 +738,8 @@ public:
   }
   /// Creates a new table type from the specified value type, minimum size, and
   /// maximum size.
-  TableType(ValType ty, uint32_t min, uint32_t max) : ptr(nullptr), ref(nullptr) {
+  TableType(ValType ty, uint32_t min, uint32_t max)
+      : ptr(nullptr), ref(nullptr) {
     wasm_limits_t limits;
     limits.min = min;
     limits.max = max;

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -620,8 +620,9 @@ public:
     std::optional<uint64_t> max() const {
       uint64_t max = 0;
       auto present = wasmtime_memorytype_maximum(ptr, &max);
-      if (present)
+      if (present) {
         return max;
+      }
       return std::nullopt;
     }
 
@@ -710,7 +711,7 @@ public:
 
     /// Returns the maximum size of this table type, in elements, if present.
     std::optional<uint32_t> max() const {
-      auto *limits = wasm_tabletype_limits(ptr);
+      const auto *limits = wasm_tabletype_limits(ptr);
       if (limits->max == wasm_limits_max_default) {
         return std::nullopt;
       }

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -524,6 +524,8 @@ class ValType {
       return WASM_FUNCREF;
     case ValKind::V128:
       return WASMTIME_V128;
+    default:
+      abort();
     }
   }
 
@@ -2208,11 +2210,7 @@ public:
   }
 
   /// Returns the current value of this global.
-  Val get(Store::Context cx) const {
-    Val val;
-    wasmtime_global_get(cx.ptr, &global, &val.val);
-    return val;
-  }
+  Val get(Store::Context cx) const;
 
   /// Sets this global to a new value.
   ///
@@ -2317,6 +2315,14 @@ public:
     return prev;
   }
 };
+
+// gcc 8.3.0 seems to require that this comes after the definition of `Table`. I
+// don't know why...
+inline Val Global::get(Store::Context cx) const {
+  Val val;
+  wasmtime_global_get(cx.ptr, &global, &val.val);
+  return val;
+}
 
 /**
  * \brief A WebAssembly linear memory.

--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -220,10 +220,10 @@ TEST(Global, Smoke) {
 TEST(Table, Smoke) {
   Engine engine;
   Store store(engine);
-  Table::create(store, TableType(ValKind::I32, Limits(1)), 3.0).err();
+  Table::create(store, TableType(ValKind::I32, 1), 3.0).err();
 
   Val null = std::optional<Func>();
-  Table t = unwrap(Table::create(store, TableType(ValKind::FuncRef, Limits(1)), null));
+  Table t = unwrap(Table::create(store, TableType(ValKind::FuncRef, 1), null));
   EXPECT_FALSE(t.get(store, 1));
   EXPECT_TRUE(t.get(store, 0));
   Val val = *t.get(store, 0);
@@ -239,19 +239,19 @@ TEST(Table, Smoke) {
 TEST(Memory, Smoke) {
   Engine engine;
   Store store(engine);
-  Memory m = unwrap(Memory::create(store, MemoryType(Limits(1))));
+  Memory m = unwrap(Memory::create(store, MemoryType(1)));
   EXPECT_EQ(m.size(store), 1);
   EXPECT_EQ(unwrap(m.grow(store, 1)), 1);
   EXPECT_EQ(m.data(store).size(), 2 << 16);
-  EXPECT_EQ(m.type(store)->limits().min(), 1);
+  EXPECT_EQ(m.type(store)->min(), 1);
 }
 
 TEST(Instance, Smoke) {
   Engine engine;
   Store store(engine);
-  Memory m = unwrap(Memory::create(store, MemoryType(Limits(1))));
+  Memory m = unwrap(Memory::create(store, MemoryType(1)));
   Global g = unwrap(Global::create(store, GlobalType(ValKind::I32, false), 1));
-  Table t = unwrap(Table::create(store, TableType(ValKind::FuncRef, Limits(1)), std::optional<Func>()));
+  Table t = unwrap(Table::create(store, TableType(ValKind::FuncRef, 1), std::optional<Func>()));
   Func f(store, FuncType({}, {}), [](auto caller, auto params, auto results) -> auto {
     return std::monostate();
   });
@@ -323,7 +323,7 @@ TEST(Caller, Smoke) {
     EXPECT_TRUE(caller.get_export("m"));
     EXPECT_TRUE(caller.get_export("f"));
     Memory m = std::get<Memory>(*caller.get_export("m"));
-    EXPECT_EQ(m.type(caller)->limits().min(), 1);
+    EXPECT_EQ(m.type(caller)->min(), 1);
     return std::monostate();
   });
   Instance i = unwrap(Instance::create(store, m, {f2}));

--- a/tests/types.cc
+++ b/tests/types.cc
@@ -12,16 +12,6 @@ T unwrap(Result<T, E> result) {
   std::abort();
 }
 
-TEST(Limits, Smoke) {
-  Limits limits(1);
-  EXPECT_EQ(limits.min(), 1);
-  EXPECT_EQ(limits.max(), std::nullopt);
-
-  limits = Limits(2, 3);
-  EXPECT_EQ(limits.min(), 2);
-  EXPECT_EQ(limits.max(), 3);
-}
-
 TEST(ValType, Smoke) {
   EXPECT_EQ(ValType(ValKind::I32)->kind(), ValKind::I32);
   EXPECT_EQ(ValType(ValKind::I64)->kind(), ValKind::I64);
@@ -42,19 +32,19 @@ TEST(ValType, Smoke) {
 }
 
 TEST(MemoryType, Smoke) {
-  MemoryType t(Limits(1));
+  MemoryType t(1);
 
-  EXPECT_EQ(t->limits().min(), 1);
-  EXPECT_EQ(t->limits().max(), std::nullopt);
+  EXPECT_EQ(t->min(), 1);
+  EXPECT_EQ(t->max(), std::nullopt);
   MemoryType t2 = t;
   t2 = t;
 }
 
 TEST(TableType, Smoke) {
-  TableType t(ValKind::FuncRef, Limits(1));
+  TableType t(ValKind::FuncRef, 1);
 
-  EXPECT_EQ(t->limits().min(), 1);
-  EXPECT_EQ(t->limits().max(), std::nullopt);
+  EXPECT_EQ(t->min(), 1);
+  EXPECT_EQ(t->max(), std::nullopt);
   EXPECT_EQ(t->element().kind(), ValKind::FuncRef);
 
   TableType t2 = t;
@@ -158,4 +148,18 @@ TEST(InstanceType, Smoke) {
   auto export_ty = std::get<GlobalType::Ref>(ExternType::from_export(e));
   EXPECT_EQ(export_ty.content().kind(), ValKind::I32);
   EXPECT_FALSE(export_ty.is_mutable());
+}
+
+TEST(MemoryType, SixtyFour) {
+  MemoryType t(1);
+  EXPECT_FALSE(t->is_64());
+  t = MemoryType::New64(1);
+  EXPECT_TRUE(t->is_64());
+  EXPECT_EQ(t->min(), 1);
+  EXPECT_EQ(t->max(), std::nullopt);
+
+  t = MemoryType::New64(0x100000000, 0x100000001);
+  EXPECT_TRUE(t->is_64());
+  EXPECT_EQ(t->min(), 0x100000000);
+  EXPECT_EQ(t->max(), 0x100000001);
 }


### PR DESCRIPTION


This implements supported added in Wasmtime for the memory64 proposal,
tweaking a few APIs as necessary. Notably the `Limits` class is now gone
in favor of direct accessors.

