### PR TITLE
Fix compiler issue on gcc 7

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -1789,7 +1789,8 @@ public:
   /// Note that `val` should be safe to send across threads and should own any
   /// memory that it points to. Also note that `ExternRef` is similar to a
   /// `std::shared_ptr` in that there can be many references to the same value.
-  explicit ExternRef(std::any val)
+  template <typename T>
+  explicit ExternRef(T val)
       : ExternRef(wasmtime_externref_new(
             std::make_unique<std::any>(std::move(val)).release(), finalizer)) {}
   /// Performs a shallow copy of another `externref` value, creating another


### PR DESCRIPTION
This PR addresses #11 by using a template constructor for ExternRef rather than std::any which seems to give gcc 7.5 issues.

3rd times a charm hopefully :)