### PR TITLE
Bind the new `*_unchecked` function APIs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: sudo apt-get update -y && sudo apt-get install -y libclang1-9 libclang-cpp9
-    - run: curl -L https://doxygen.nl/files/doxygen-1.9.1.linux.bin.tar.gz | tar xzf -
-    - run: echo "`pwd`/doxygen-1.9.1/bin" >> $GITHUB_PATH
+    - run: curl -L https://doxygen.nl/files/doxygen-1.9.2.linux.bin.tar.gz | tar xzf -
+    - run: echo "`pwd`/doxygen-1.9.2/bin" >> $GITHUB_PATH
     - run: doxygen doxygen.conf
     - run: tar czf html.tar.gz html
     - uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 option(ENABLE_CODE_ANALYSIS "Run code analysis" OFF)
 message(STATUS "ENABLE_CODE_ANALYSIS       ${ENABLE_CODE_ANALYSIS}")
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   add_compile_options (-fdiagnostics-color=always)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+   add_compile_options (-fcolor-diagnostics)
+endif ()
+
 add_library(wasmtime-cpp INTERFACE ${CMAKE_SOURCE_DIR}/include/wasmtime.hh)
 target_link_libraries(wasmtime-cpp INTERFACE wasmtime)
 if (MSVC)

--- a/doxygen.conf
+++ b/doxygen.conf
@@ -810,7 +810,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters
@@ -1886,7 +1886,7 @@ PDF_HYPERLINKS         = YES
 # The default value is: YES.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-USE_PDFLATEX           = YES
+USE_PDFLATEX           = NO
 
 # If the LATEX_BATCHMODE tag is set to YES, doxygen will add the \batchmode
 # command to the generated LaTeX files. This will instruct LaTeX to keep running

--- a/examples/hello.cc
+++ b/examples/hello.cc
@@ -31,16 +31,10 @@ int main() {
 
   // Our wasm module we'll be instantiating requires one imported function.
   // the function takes no parameters and returns no results. We create a host
-  // implementation of that function here, and the `caller` parameter here is
-  // used to get access to our original `MyState` value.
+  // implementation of that function here.
   std::cout << "Creating callback...\n";
-  FuncType ty({}, {});
-  Func host_func(store, ty, [](auto caller, auto args, auto results) -> auto {
+  Func host_func = Func::wrap(store, []() {
       std::cout << "Calling back...\n";
-      (void) caller;
-      (void) args;
-      (void) results;
-      return std::monostate();
   });
 
   // Once we've got that all set up we can then move to the instantiation

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -33,6 +33,7 @@
 #define WASMTIME_HH
 
 #include <any>
+#include <array>
 #include <initializer_list>
 #include <iostream>
 #include <limits>
@@ -128,6 +129,9 @@ public:
     wasmtime_error_delete(error);
   }
 
+  /// \brief Creates a custom error from a custom error string.
+  Error(std::string_view msg) : msg(msg) {}
+
   /// \brief Returns the error message associated with this error.
   std::string_view message() const { return msg; }
 };
@@ -156,7 +160,7 @@ public:
 
   /// \brief Returns `true` if this result is a success, `false` if it's an
   /// error
-  explicit operator bool() { return data.index() == 0; }
+  explicit operator bool() const { return data.index() == 0; }
 
   /// \brief Returns the error, if present, aborts if this is not an error.
   E &&err() { return std::get<E>(std::move(data)); }
@@ -173,6 +177,11 @@ public:
     if (*this) {
       return this->ok();
     }
+    abort();
+  }
+
+private:
+  [[noreturn]] void abort() {
     std::cerr << "error: " << this->err().message() << "\n";
     std::abort();
   }
@@ -456,6 +465,36 @@ enum class ValKind {
   /// WebAssembly's `funcref` type from the reference types
   FuncRef,
 };
+
+/// \brief Used to print a ValKind.
+inline std::ostream &operator<<(std::ostream &os, const ValKind &e) {
+  switch (e) {
+  case ValKind::I32:
+    os << "i32";
+    break;
+  case ValKind::I64:
+    os << "i64";
+    break;
+  case ValKind::F32:
+    os << "f32";
+    break;
+  case ValKind::F64:
+    os << "f64";
+    break;
+  case ValKind::ExternRef:
+    os << "externref";
+    break;
+  case ValKind::FuncRef:
+    os << "funcref";
+    break;
+  case ValKind::V128:
+    os << "v128";
+    break;
+  default:
+    abort();
+  }
+  return os;
+}
 
 /**
  * \brief Type information about a WebAssembly value.
@@ -880,21 +919,7 @@ public:
   FuncType(std::initializer_list<ValType> params,
            std::initializer_list<ValType> results)
       : ref(nullptr) {
-    wasm_valtype_vec_t param_vec;
-    wasm_valtype_vec_t result_vec;
-    wasm_valtype_vec_new_uninitialized(&param_vec, params.size());
-    wasm_valtype_vec_new_uninitialized(&result_vec, results.size());
-    size_t i = 0;
-    for (auto val : params) {
-      param_vec.data[i++] = val.ptr.release(); // NOLINT
-    }
-    i = 0;
-    for (auto val : results) {
-      result_vec.data[i++] = val.ptr.release(); // NOLINT
-    }
-
-    ptr.reset(wasm_functype_new(&param_vec, &result_vec));
-    ref = ptr.get();
+    *this = FuncType::from_iters(params, results);
   }
 
   /// Copies a reference into a uniquely owned function type.
@@ -913,6 +938,26 @@ public:
   /// Moves type information from anothe type into this one.
   FuncType &operator=(FuncType &&other) = default;
 
+  /// Creates a new function type from the given list of parameters and results.
+  template <typename P, typename R>
+  static FuncType from_iters(P params, R results) {
+    wasm_valtype_vec_t param_vec;
+    wasm_valtype_vec_t result_vec;
+    wasm_valtype_vec_new_uninitialized(&param_vec, params.size());
+    wasm_valtype_vec_new_uninitialized(&result_vec, results.size());
+    size_t i = 0;
+
+    for (auto val : params) {
+      param_vec.data[i++] = val.ptr.release(); // NOLINT
+    }
+    i = 0;
+    for (auto val : results) {
+      result_vec.data[i++] = val.ptr.release(); // NOLINT
+    }
+
+    return wasm_functype_new(&param_vec, &result_vec);
+  }
+
   /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
   /// this instance.
   Ref *operator->() { return &ref; }
@@ -929,7 +974,6 @@ public:
   /// Non-owning reference to an `ImportType`, must not be used after the
   /// original owner is deleted.
   class Ref {
-    friend class TypeList;
     friend class ExternType;
 
     const wasm_importtype_t *ptr;
@@ -1329,6 +1373,7 @@ class Trap {
   friend class Linker;
   friend class Instance;
   friend class Func;
+  template <typename Params, typename Results> friend class TypedFunc;
 
   struct deleter {
     void operator()(wasm_trap_t *p) const { wasm_trap_delete(p); }
@@ -1642,6 +1687,7 @@ public:
 };
 
 class Caller;
+template <typename Params, typename Results> class TypedFunc;
 
 /**
  * \brief Owner of all WebAssembly objects
@@ -1768,6 +1814,9 @@ public:
       }
       return std::nullopt;
     }
+
+    /// Returns the raw context pointer for the C API.
+    wasmtime_context_t *raw_context() { return ptr; }
   };
 
   /// Explicit function to acquire a `Context` from this store.
@@ -1798,9 +1847,10 @@ class ExternRef {
     std::unique_ptr<std::any> _ptr(static_cast<std::any *>(ptr));
   }
 
-  ExternRef(wasmtime_externref_t *ptr) : ptr(ptr) {}
-
 public:
+  /// Creates a new `ExternRef` from an owned C API raw pointer.
+  explicit ExternRef(wasmtime_externref_t *ptr) : ptr(ptr) {}
+
   /// Creates a new `externref` value from the provided argument.
   ///
   /// Note that `val` should be safe to send across threads and should own any
@@ -1830,6 +1880,11 @@ public:
   std::any &data() {
     return *static_cast<std::any *>(wasmtime_externref_data(ptr.get()));
   }
+
+  /// Returns the raw underlying C API pointer.
+  ///
+  /// This class still retains ownership of the pointer.
+  wasmtime_externref_t *raw() const { return ptr.get(); }
 };
 
 class Func;
@@ -1841,6 +1896,20 @@ class Table;
 /// \typedef Extern
 /// \brief Representation of an external WebAssembly item
 typedef std::variant<Instance, Module, Func, Global, Memory, Table> Extern;
+
+/// \brief Container for the `v128` WebAssembly type.
+struct V128 {
+  /// \brief The little-endian bytes of the `v128` value.
+  wasmtime_v128 v128;
+
+  /// \brief Creates a new zero-value `v128`.
+  V128() : v128{} { memset(&v128[0], 0, sizeof(wasmtime_v128)); }
+
+  /// \brief Creates a new `V128` from its C API representation.
+  V128(const wasmtime_v128 &v) : v128{} {
+    memcpy(&v128[0], &v[0], sizeof(wasmtime_v128));
+  }
+};
 
 /**
  * \brief Representation of a generic WebAssembly value.
@@ -1884,10 +1953,9 @@ public:
     val.of.f64 = f64;
   }
   /// Creates a new `v128` WebAssembly value.
-  Val(const wasmtime_v128 &v128) : val{} {
+  Val(const V128 &v128) : val{} {
     val.kind = WASMTIME_V128;
-    val.of.i32 = 0;
-    memcpy(&val.of.v128[0], &v128[0], sizeof(wasmtime_v128));
+    memcpy(&val.of.v128[0], &v128.v128[0], sizeof(wasmtime_v128));
   }
   /// Creates a new `funcref` WebAssembly value.
   Val(std::optional<Func> func);
@@ -1996,7 +2064,7 @@ public:
 
   /// Returns the underlying `v128`, requires `kind() == KindV128` or aborts
   /// the process.
-  const wasmtime_v128 &v128() const {
+  V128 v128() const {
     if (val.kind != WASMTIME_V128) {
       std::abort();
     }
@@ -2054,6 +2122,241 @@ inline Store::Context::Context(Caller &caller)
     : Context(wasmtime_caller_context(caller.ptr)) {}
 inline Store::Context::Context(Caller *caller) : Context(*caller) {}
 
+namespace detail {
+
+/// A "trait" for native types that correspond to WebAssembly types for use with
+/// `Func::wrap` and `TypedFunc::call`
+template <typename T> struct WasmType { static const bool valid = false; };
+
+/// Helper macro to define `WasmType` definitions for primitive types like
+/// int32_t and such.
+// NOLINTNEXTLINE
+#define NATIVE_WASM_TYPE(native, valkind, field)                               \
+  template <> struct WasmType<native> {                                        \
+    static const bool valid = true;                                            \
+    static const ValKind kind = ValKind::valkind;                              \
+    static void store(Store::Context cx, wasmtime_val_raw_t *p,                \
+                      const native &t) {                                       \
+      p->field = t;                                                            \
+    }                                                                          \
+    static native load(Store::Context cx, wasmtime_val_raw_t *p) {             \
+      return p->field;                                                         \
+    }                                                                          \
+  };
+
+NATIVE_WASM_TYPE(int32_t, I32, i32)
+NATIVE_WASM_TYPE(uint32_t, I32, i32)
+NATIVE_WASM_TYPE(int64_t, I64, i64)
+NATIVE_WASM_TYPE(uint64_t, I64, i64)
+NATIVE_WASM_TYPE(float, F32, f32)
+NATIVE_WASM_TYPE(double, F64, f64)
+
+#undef NATIVE_WASM_TYPE
+
+/// Type information for `externref`, represented on the host as an optional
+/// `ExternRef`.
+template <> struct WasmType<std::optional<ExternRef>> {
+  static const bool valid = true;
+  static const ValKind kind = ValKind::ExternRef;
+  static void store(Store::Context cx, wasmtime_val_raw_t *p,
+                    const std::optional<ExternRef> &ref) {
+    if (ref) {
+      p->externref = wasmtime_externref_to_raw(cx.raw_context(), ref->raw());
+    } else {
+      p->externref = 0;
+    }
+  }
+  static std::optional<ExternRef> load(Store::Context cx,
+                                       wasmtime_val_raw_t *p) {
+    if (p->externref == 0) {
+      return std::nullopt;
+    }
+    return ExternRef(
+        wasmtime_externref_from_raw(cx.raw_context(), p->externref));
+  }
+};
+
+/// Type information for the `V128` host value used as a wasm value.
+template <> struct WasmType<V128> {
+  static const bool valid = true;
+  static const ValKind kind = ValKind::V128;
+  static void store(Store::Context cx, wasmtime_val_raw_t *p, const V128 &t) {
+    memcpy(&p->v128[0], &t.v128[0], sizeof(wasmtime_v128));
+  }
+  static V128 load(Store::Context cx, wasmtime_val_raw_t *p) { return p->v128; }
+};
+
+/// A "trait" for a list of types and operations on them, used for `Func::wrap`
+/// and `TypedFunc::call`
+///
+/// The base case is a single type which is a list of one element.
+template <typename T> struct WasmTypeList {
+  static const bool valid = WasmType<T>::valid;
+  static const size_t size = 1;
+  static bool matches(ValType::ListRef types) {
+    return WasmTypeList<std::tuple<T>>::matches(types);
+  }
+  static void store(Store::Context cx, wasmtime_val_raw_t *storage,
+                    const T &t) {
+    WasmType<T>::store(cx, storage, t);
+  }
+  static T load(Store::Context cx, wasmtime_val_raw_t *storage) {
+    return WasmType<T>::load(cx, storage);
+  }
+  static std::vector<ValType> types() { return {WasmType<T>::kind}; }
+};
+
+/// std::monostate translates to an empty list of types.
+template <> struct WasmTypeList<std::monostate> {
+  static const bool valid = true;
+  static const size_t size = 0;
+  static bool matches(ValType::ListRef types) { return types.size() == 0; }
+  static void store(Store::Context cx, wasmtime_val_raw_t *storage,
+                    const std::monostate &t) {}
+  static std::monostate load(Store::Context cx, wasmtime_val_raw_t *storage) {
+    return std::monostate();
+  }
+  static std::vector<ValType> types() { return {}; }
+};
+
+/// std::tuple<> translates to the corresponding list of types
+template <typename... T> struct WasmTypeList<std::tuple<T...>> {
+  static const bool valid = (WasmType<T>::valid && ...);
+  static const size_t size = sizeof...(T);
+  static bool matches(ValType::ListRef types) {
+    if (types.size() != size) {
+      return false;
+    }
+    size_t n = 0;
+    return ((WasmType<T>::kind == types.begin()[n++].kind()) && ...);
+  }
+  static void store(Store::Context cx, wasmtime_val_raw_t *storage,
+                    const std::tuple<T...> &t) {
+    size_t n = 0;
+    std::apply(
+        [&](const auto &...val) {
+          (WasmType<T>::store(cx, &storage[n++], val), ...); // NOLINT
+        },
+        t);
+  }
+  static std::tuple<T...> load(Store::Context cx, wasmtime_val_raw_t *storage) {
+    size_t n = 0;
+    return std::tuple<T...>{WasmType<T>::load(cx, &storage[n++])...}; // NOLINT
+  }
+  static std::vector<ValType> types() { return {WasmType<T>::kind...}; }
+};
+
+/// A "trait" for what can be returned from closures specified to `Func::wrap`.
+///
+/// The base case here is a bare return value like `int32_t`.
+template <typename R> struct WasmHostRet {
+  using Results = WasmTypeList<R>;
+
+  template <typename F, typename... A>
+  static std::optional<Trap> invoke(F f, Caller cx, wasmtime_val_raw_t *raw,
+                                    A... args) {
+    auto ret = f(args...);
+    Results::store(cx, raw, ret);
+    return std::nullopt;
+  }
+};
+
+/// Host functions can return nothing
+template <> struct WasmHostRet<void> {
+  using Results = WasmTypeList<std::tuple<>>;
+
+  template <typename F, typename... A>
+  static std::optional<Trap> invoke(F f, Caller cx, wasmtime_val_raw_t *raw,
+                                    A... args) {
+    f(args...);
+    return std::nullopt;
+  }
+};
+
+// Alternative method of returning "nothing" (also enables `std::monostate` in
+// the `R` type of `Result` below)
+template <> struct WasmHostRet<std::monostate> : public WasmHostRet<void> {};
+
+/// Host functions can return a result which allows them to also possibly return
+/// a trap.
+template <typename R> struct WasmHostRet<Result<R, Trap>> {
+  using Results = WasmTypeList<R>;
+
+  template <typename F, typename... A>
+  static std::optional<Trap> invoke(F f, Caller cx, wasmtime_val_raw_t *raw,
+                                    A... args) {
+    Result<R, Trap> ret = f(args...);
+    if (!ret) {
+      return ret.err();
+    }
+    Results::store(cx, raw, ret.ok());
+    return std::nullopt;
+  }
+};
+
+template <typename F, typename = void> struct WasmHostFunc;
+
+/// Base type information for host function pointers being used as wasm
+/// functions
+template <typename R, typename... A> struct WasmHostFunc<R (*)(A...)> {
+  using Params = WasmTypeList<std::tuple<A...>>;
+  using Results = typename WasmHostRet<R>::Results;
+
+  template <typename F>
+  static std::optional<Trap> invoke(F &f, Caller cx, wasmtime_val_raw_t *raw) {
+    auto params = Params::load(cx, raw);
+    return std::apply(
+        [&](const auto &...val) {
+          return WasmHostRet<R>::invoke(f, cx, raw, val...);
+        },
+        params);
+  }
+};
+
+/// Function type information, but with a `Caller` first parameter
+template <typename R, typename... A>
+struct WasmHostFunc<R (*)(Caller, A...)> : public WasmHostFunc<R (*)(A...)> {
+  // Override `invoke` here to pass the `cx` as the first parameter
+  template <typename F>
+  static std::optional<Trap> invoke(F &f, Caller cx, wasmtime_val_raw_t *raw) {
+    auto params = WasmTypeList<std::tuple<A...>>::load(cx, raw);
+    return std::apply(
+        [&](const auto &...val) {
+          return WasmHostRet<R>::invoke(f, cx, raw, cx, val...);
+        },
+        params);
+  }
+};
+
+/// Function type information, but with as a host method.
+template <typename R, typename C, typename... A>
+struct WasmHostFunc<R (C::*)(A...)> : public WasmHostFunc<R (*)(A...)> {};
+
+/// Function type information, but with as a const host method.
+template <typename R, typename C, typename... A>
+struct WasmHostFunc<R (C::*)(A...) const> : public WasmHostFunc<R (*)(A...)> {};
+
+/// Function type information, but with as a host method with a `Caller` first
+/// parameter.
+template <typename R, typename C, typename... A>
+struct WasmHostFunc<R (C::*)(Caller, A...)>
+    : public WasmHostFunc<R (*)(Caller, A...)> {};
+
+/// Function type information, but with as a host const method with a `Caller`
+/// first parameter.
+template <typename R, typename C, typename... A>
+struct WasmHostFunc<R (C::*)(Caller, A...) const>
+    : public WasmHostFunc<R (*)(Caller, A...)> {};
+
+// Forward... something? Not entirely sure but this makes things work.
+template <typename T>
+struct WasmHostFunc<T, std::void_t<decltype(&T::operator())>>
+    : public WasmHostFunc<decltype(&T::operator())> {};
+
+} // namespace detail
+
+using namespace detail;
+
 /**
  * \brief Representation of a WebAssembly function.
  *
@@ -2069,6 +2372,7 @@ class Func {
   friend class Val;
   friend class Instance;
   friend class Linker;
+  template <typename Params, typename Results> friend class TypedFunc;
 
   wasmtime_func_t func;
 
@@ -2089,6 +2393,20 @@ class Func {
     return nullptr;
   }
 
+  template <typename F>
+  static wasm_trap_t *
+  raw_callback_unchecked(void *env, wasmtime_caller_t *caller,
+                         wasmtime_val_raw_t *args_and_results) {
+    using HostFunc = WasmHostFunc<F>;
+    Caller cx(caller);
+    F *func = reinterpret_cast<F *>(env); // NOLINT
+    auto trap = HostFunc::invoke(*func, cx, args_and_results);
+    if (trap) {
+      return trap->ptr.release();
+    }
+    return nullptr;
+  }
+
   template <typename F> static void raw_finalize(void *env) {
     std::unique_ptr<F> ptr(reinterpret_cast<F *>(env)); // NOLINT
   }
@@ -2103,6 +2421,9 @@ public:
    * This constructor is used to create a host function within the store
    * provided. This is how WebAssembly can call into the host and make use of
    * external functionality.
+   *
+   * > **Note**: host functions created this way are more flexible but not
+   * > as fast to call as those created by `Func::wrap`.
    *
    * \param cx the store to create the function within
    * \param ty the type of the function that will be created
@@ -2125,10 +2446,67 @@ public:
    * finish successfully. If a trap is raised then the results pointer does not
    * need to be written to.
    */
-  template <typename F>
+  template <typename F,
+            std::enable_if_t<
+                std::is_invocable_r_v<Result<std::monostate, Trap>, F, Caller,
+                                      Span<const Val>, Span<Val>>,
+                bool> = true>
   Func(Store::Context cx, const FuncType &ty, F f) : func({}) {
     wasmtime_func_new(cx.ptr, ty.ptr.get(), raw_callback<F>,
                       std::make_unique<F>(f).release(), raw_finalize<F>, &func);
+  }
+
+  /**
+   * \brief Creates a new host function from the provided callback `f`,
+   * inferring the WebAssembly function type from the host signature.
+   *
+   * This function is akin to the `Func` constructor except that the WebAssembly
+   * type does not need to be specified and additionally the signature of `f`
+   * is different. The main goal of this function is to enable WebAssembly to
+   * call the function `f` as-fast-as-possible without having to validate any
+   * types or such.
+   *
+   * The function `f` can optionally take a `Caller` as its first parameter,
+   * but otherwise its arguments are translated to WebAssembly types:
+   *
+   * * `int32_t`, `uint32_t` - `i32`
+   * * `int64_t`, `uint64_t` - `i64`
+   * * `float` - `f32`
+   * * `double` - `f64`
+   * * `std::optional<Func>` - `funcref`
+   * * `std::optional<ExternRef>` - `externref`
+   * * `wasmtime::V128` - `v128`
+   *
+   * The function may only take these arguments and if it takes any other kinds
+   * of arguments then it will fail to compile.
+   *
+   * The function may return a few different flavors of return values:
+   *
+   * * `void` - interpreted as returning nothing
+   * * Any type above - interpreted as a singular return value.
+   * * `std::tuple<T...>` where `T` is one of the valid argument types -
+   *   interpreted as returning multiple values.
+   * * `Result<T, Trap>` where `T` is another valid return type - interpreted as
+   *   a function that returns `T` to wasm but is optionally allowed to also
+   *   raise a trap.
+   *
+   * It's recommended, if possible, to use this function over the `Func`
+   * constructor since this is generally easier to work with and also enables
+   * a faster path for WebAssembly to call this function.
+   */
+  template <typename F,
+            std::enable_if_t<WasmHostFunc<F>::Params::valid, bool> = true,
+            std::enable_if_t<WasmHostFunc<F>::Results::valid, bool> = true>
+  static Func wrap(Store::Context cx, F f) {
+    using HostFunc = WasmHostFunc<F>;
+    auto params = HostFunc::Params::types();
+    auto results = HostFunc::Results::types();
+    auto ty = FuncType::from_iters(params, results);
+    wasmtime_func_t func;
+    wasmtime_func_new_unchecked(cx.ptr, ty.ptr.get(), raw_callback_unchecked<F>,
+                                std::make_unique<F>(f).release(),
+                                raw_finalize<F>, &func);
+    return func;
   }
 
   /**
@@ -2146,6 +2524,10 @@ public:
    * * Otherwise a `Trap` might be generated by the WebAssembly function.
    * * Finally an `Error` could be returned indicating that `params` were not of
    *   the right type.
+   *
+   * > **Note**: for optimized calls into WebAssembly where the function
+   * > signature is statically known it's recommended to use `Func::typed` and
+   * > `TypedFunc::call`.
    */
   [[nodiscard]] TrapResult<std::vector<Val>>
   call(Store::Context cx, const std::vector<Val> &params) const {
@@ -2180,6 +2562,76 @@ public:
   FuncType type(Store::Context cx) const {
     return wasmtime_func_type(cx.ptr, &func);
   }
+
+  /**
+   * \brief Statically checks this function against the provided types.
+   *
+   * This function will check whether it takes the statically known `Params`
+   * and returns the statically known `Results`. If the type check succeeds then
+   * a `TypedFunc` is returned which enables a faster method of invoking
+   * WebAssembly functions.
+   *
+   * The `Params` and `Results` specified as template parameters here are the
+   * parameters and results of the wasm function. They can either be a bare
+   * type which means that the wasm takes/returns one value, or they can be a
+   * `std::tuple<T...>` of types to represent multiple arguments or multiple
+   * returns.
+   *
+   * The valid types for this function are those mentioned as the arguments
+   * for `Func::wrap`.
+   */
+  template <typename Params, typename Results,
+            std::enable_if_t<WasmTypeList<Params>::valid, bool> = true,
+            std::enable_if_t<WasmTypeList<Results>::valid, bool> = true>
+  Result<TypedFunc<Params, Results>> typed(Store::Context cx) const {
+    auto ty = this->type(cx);
+    if (!WasmTypeList<Params>::matches(ty->params()) ||
+        !WasmTypeList<Results>::matches(ty->results())) {
+      return Error("static type for this function does not match actual type");
+    }
+    TypedFunc<Params, Results> ret(*this);
+    return ret;
+  }
+
+  /// Returns the raw underlying C API function this is using.
+  const wasmtime_func_t &raw_func() const { return func; }
+};
+
+/**
+ * \brief A version of a WebAssembly `Func` where the type signature of the
+ * function is statically known.
+ */
+template <typename Params, typename Results> class TypedFunc {
+  friend class Func;
+  Func f;
+  TypedFunc(Func func) : f(func) {}
+
+public:
+  /**
+   * \brief Calls this function with the provided parameters.
+   *
+   * This function is akin to `Func::call` except that since static type
+   * information is available it statically takes its parameters and statically
+   * returns its results.
+   *
+   * Note that this function still may return a `Trap` indicating that calling
+   * the WebAssembly function failed.
+   */
+  Result<Results, Trap> call(Store::Context cx, Params params) const {
+    std::array<wasmtime_val_raw_t, std::max(WasmTypeList<Params>::size,
+                                            WasmTypeList<Results>::size)>
+        storage;
+    WasmTypeList<Params>::store(cx, storage.data(), params);
+    auto *trap =
+        wasmtime_func_call_unchecked(cx.raw_context(), &f.func, storage.data());
+    if (trap != nullptr) {
+      return Trap(trap);
+    }
+    return WasmTypeList<Results>::load(cx, storage.data());
+  }
+
+  /// Returns the underlying un-typed `Func` for this function.
+  const Func &func() const { return f; }
 };
 
 inline Val::Val(std::optional<Func> func) : val{} {
@@ -2203,6 +2655,32 @@ inline std::optional<Func> Val::funcref() const {
   }
   return Func(val.of.funcref);
 }
+
+/// Definition for the `funcref` native wasm type
+template <> struct detail::WasmType<std::optional<Func>> {
+  /// @private
+  static const bool valid = true;
+  /// @private
+  static const ValKind kind = ValKind::FuncRef;
+  /// @private
+  static void store(Store::Context cx, wasmtime_val_raw_t *p,
+                    const std::optional<Func> func) {
+    if (func) {
+      p->funcref = wasmtime_func_to_raw(cx.raw_context(), &func->raw_func());
+    } else {
+      p->funcref = 0;
+    }
+  }
+  /// @private
+  static std::optional<Func> load(Store::Context cx, wasmtime_val_raw_t *p) {
+    if (p->funcref == 0) {
+      return std::nullopt;
+    }
+    wasmtime_func_t ret;
+    wasmtime_func_from_raw(cx.raw_context(), p->funcref, &ret);
+    return ret;
+  }
+};
 
 /**
  * \brief A WebAssembly global.
@@ -2686,16 +3164,44 @@ public:
     return std::nullopt;
   }
 
-  /// Defines a new function in this linker
-  template <typename F>
-  [[nodiscard]] Result<std::monostate> define_func(std::string_view module,
-                                                   std::string_view name,
-                                                   const FuncType &ty, F f) {
+  /// Defines a new function in this linker in the style of the `Func`
+  /// constructor.
+  template <typename F,
+            std::enable_if_t<
+                std::is_invocable_r_v<Result<std::monostate, Trap>, F, Caller,
+                                      Span<const Val>, Span<Val>>,
+                bool> = true>
+  [[nodiscard]] Result<std::monostate> func_new(std::string_view module,
+                                                std::string_view name,
+                                                const FuncType &ty, F f) {
 
     auto *error = wasmtime_linker_define_func(
         ptr.get(), module.data(), module.length(), name.data(), name.length(),
         ty.ptr.get(), Func::raw_callback<F>, std::make_unique<F>(f).release(),
         Func::raw_finalize<F>);
+
+    if (error != nullptr) {
+      return Error(error);
+    }
+
+    return std::monostate();
+  }
+
+  /// Defines a new function in this linker in the style of the `Func::wrap`
+  /// constructor.
+  template <typename F,
+            std::enable_if_t<WasmHostFunc<F>::Params::valid, bool> = true,
+            std::enable_if_t<WasmHostFunc<F>::Results::valid, bool> = true>
+  [[nodiscard]] Result<std::monostate> func_wrap(std::string_view module,
+                                                 std::string_view name, F f) {
+    using HostFunc = WasmHostFunc<F>;
+    auto params = HostFunc::Params::types();
+    auto results = HostFunc::Results::types();
+    auto ty = FuncType::from_iters(params, results);
+    auto *error = wasmtime_linker_define_func_unchecked(
+        ptr.get(), module.data(), module.length(), name.data(), name.length(),
+        ty.ptr.get(), Func::raw_callback_unchecked<F>,
+        std::make_unique<F>(f).release(), Func::raw_finalize<F>);
 
     if (error != nullptr) {
       return Error(error);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ endfunction()
 
 add_test(simple)
 add_test(types)
+add_test(func)
 
 # Add a custom test where two files include `wasmtime.hh` and are compiled into
 # the same executable (basically makes sure any defined functions in the header

--- a/tests/func.cc
+++ b/tests/func.cc
@@ -1,0 +1,232 @@
+#include <gtest/gtest.h>
+#include <wasmtime.hh>
+
+using namespace wasmtime;
+using empty_t = std::tuple<>;
+
+TEST(TypedFunc, Smoke) {
+  Engine engine;
+  Store store(engine);
+  Func thunk(store, FuncType({}, {}), [](auto caller, auto params, auto results) {
+    return std::monostate();
+  });
+
+  EXPECT_FALSE((thunk.typed<int, int>(store)));
+  EXPECT_FALSE((thunk.typed<float, std::tuple<int32_t, uint32_t>>(store)));
+  EXPECT_FALSE((thunk.typed<float, empty_t>(store)));
+  EXPECT_TRUE((thunk.typed<empty_t, empty_t>(store)));
+
+  Func pi32(store, FuncType({ValKind::I32}, {}), [](auto caller, auto params, auto results) {
+    return std::monostate();
+  });
+
+  EXPECT_FALSE((pi32.typed<float, empty_t>(store)));
+  EXPECT_TRUE((pi32.typed<std::tuple<int32_t>, empty_t>(store)));
+  EXPECT_TRUE((pi32.typed<int32_t, empty_t>(store)));
+  EXPECT_TRUE((pi32.typed<std::tuple<uint32_t>, empty_t>(store)));
+  EXPECT_TRUE((pi32.typed<uint32_t, empty_t>(store)));
+
+  Func rets(store, FuncType({}, {ValKind::F32, ValKind::F64}), [](auto caller, auto params, auto results) {
+    return std::monostate();
+  });
+
+  EXPECT_FALSE((rets.typed<empty_t, std::tuple<int, int>>(store)));
+  EXPECT_FALSE((rets.typed<empty_t, empty_t>(store)));
+  EXPECT_TRUE((rets.typed<empty_t, std::tuple<float, double>>(store)));
+}
+
+TEST(TypedFunc, Call) {
+  Engine engine;
+  Store store(engine);
+
+  {
+    Func thunk(store, FuncType({}, {}), [](auto caller, auto params, auto results) {
+      return std::monostate();
+    });
+    auto func = thunk.typed<empty_t, empty_t>(store).unwrap();
+    empty_t result = func.call(store, empty_t()).unwrap();
+  }
+
+  {
+    Func f(store, FuncType({ValKind::I32}, {}), [](auto caller, auto params, auto results) {
+      EXPECT_EQ(params[0].i32(), 1);
+      return std::monostate();
+    });
+
+    f.typed<int32_t, empty_t>(store).unwrap().call(store, 1).unwrap();
+    f.typed<std::tuple<int32_t>, empty_t>(store).unwrap().call(store, {1}).unwrap();
+  }
+  {
+    Func f(store, FuncType({ValKind::F32, ValKind::I64}, {ValKind::I32, ValKind::F64}), [](auto caller, auto params, auto results) {
+      EXPECT_EQ(params[0].f32(), 1);
+      EXPECT_EQ(params[1].i64(), 2);
+      results[0] = int32_t(3);
+      results[1] = double(4);
+      return std::monostate();
+    });
+
+    auto func = f.typed<std::tuple<float, uint64_t>, std::tuple<uint32_t, double>>(store).unwrap();
+    auto result = func.call(store, {1, 2}).unwrap();
+    EXPECT_EQ(std::get<0>(result), 3);
+    EXPECT_EQ(std::get<1>(result), 4);
+  }
+
+  {
+    FuncType ty({ValKind::ExternRef, ValKind::ExternRef}, {ValKind::ExternRef, ValKind::ExternRef});
+    Func f(store, ty, [](auto caller, auto params, auto results) {
+      caller.context().gc();
+      EXPECT_TRUE(params[0].externref());
+      EXPECT_EQ(std::any_cast<int>(params[0].externref()->data()), 100);
+      EXPECT_FALSE(params[1].externref());
+      results[0] = ExternRef(int(3));
+      results[1] = std::optional<ExternRef>(std::nullopt);
+      caller.context().gc();
+      return std::monostate();
+    });
+
+    using ExternRefPair = std::tuple<std::optional<ExternRef>, std::optional<ExternRef>>;
+    auto func = f.typed<ExternRefPair, ExternRefPair>(store).unwrap();
+    auto result = func.call(store, {ExternRef(int(100)), std::nullopt}).unwrap();
+    store.context().gc();
+    EXPECT_EQ(std::any_cast<int>(std::get<0>(result)->data()), 3);
+    EXPECT_EQ(std::get<1>(result), std::nullopt);
+  }
+
+  {
+    Func f2(store, FuncType({}, {}), [](auto caller, auto params, auto results) {
+      return std::monostate();
+    });
+
+    FuncType ty({ValKind::FuncRef, ValKind::FuncRef}, {ValKind::FuncRef, ValKind::FuncRef});
+
+    Func f(store, ty, [&](auto caller, auto params, auto results) {
+      EXPECT_TRUE(params[0].funcref());
+      Func param = *params[0].funcref();
+      param.typed<empty_t, empty_t>(caller).unwrap().call(caller, empty_t()).unwrap();
+      EXPECT_FALSE(params[1].funcref());
+      results[0] = f2;
+      results[1] = std::optional<Func>(std::nullopt);
+      return std::monostate();
+    });
+
+    using FuncPair = std::tuple<std::optional<Func>, std::optional<Func>>;
+    auto func = f.typed<FuncPair, FuncPair>(store).unwrap();
+    auto result = func.call(store, {f2, std::nullopt}).unwrap();
+    /* EXPECT_EQ(std::any_cast<int>(std::get<0>(result)->data()), 3); */
+    Func result_f = *std::get<0>(result);
+    result_f.typed<empty_t, empty_t>(store).unwrap().call(store, empty_t()).unwrap();
+    EXPECT_EQ(std::get<1>(result), std::nullopt);
+  }
+
+  {
+    FuncType ty({ValKind::V128}, {ValKind::V128});
+
+    Func f(store, ty, [&](auto caller, auto params, auto results) {
+      V128 ret;
+      for (int i = 0; i < 16; i++) {
+        EXPECT_EQ(params[0].v128().v128[i], 1);
+        ret.v128[i] = 2;
+      }
+      results[0] = ret;
+      return std::monostate();
+    });
+
+    V128 param;
+    for (int i = 0; i < 16; i++) {
+      param.v128[i] = 1;
+    }
+    auto func = f.typed<V128, V128>(store).unwrap();
+    auto result = func.call(store, {param}).unwrap();
+    for (int i = 0; i < 16; i++) {
+      EXPECT_EQ(result.v128[i], 2);
+    }
+  }
+}
+
+void assert_types_eq(ValType::ListRef actual, std::initializer_list<ValKind> expected) {
+  EXPECT_EQ(expected.size(), actual.size());
+  std::vector<ValKind> actual_vec;
+  for (auto ty : actual) {
+    actual_vec.push_back(ty.kind());
+  }
+  std::vector<ValKind> expected_vec(expected);
+  EXPECT_EQ(actual_vec, expected_vec);
+}
+
+void assert_func_type(FuncType actual, std::initializer_list<ValKind> params, std::initializer_list<ValKind> results) {
+  assert_types_eq(actual->params(), params);
+  assert_types_eq(actual->results(), results);
+}
+
+
+TEST(TypedFunc, WrapAndTypes) {
+  Engine engine;
+  Store store(engine);
+  Func f = Func::wrap(store, []() {});
+  assert_func_type(f.type(store), {}, {});
+  f = Func::wrap(store, []() { return int32_t(1); });
+  assert_func_type(f.type(store), {}, {ValKind::I32});
+  f = Func::wrap(store, []() { return int64_t(1); });
+  assert_func_type(f.type(store), {}, {ValKind::I64});
+  f = Func::wrap(store, []() { return float(1); });
+  assert_func_type(f.type(store), {}, {ValKind::F32});
+  f = Func::wrap(store, []() { return double(1); });
+  assert_func_type(f.type(store), {}, {ValKind::F64});
+  f = Func::wrap(store, []() { return V128(); });
+  assert_func_type(f.type(store), {}, {ValKind::V128});
+  f = Func::wrap(store, []() { return std::make_tuple(int32_t(1), int32_t(2)); });
+  assert_func_type(f.type(store), {}, {ValKind::I32, ValKind::I32});
+  f = Func::wrap(store, []() { return std::optional<Func>(std::nullopt); });
+  assert_func_type(f.type(store), {}, {ValKind::FuncRef});
+  f = Func::wrap(store, []() { return std::optional<ExternRef>(std::nullopt); });
+  assert_func_type(f.type(store), {}, {ValKind::ExternRef});
+  f = Func::wrap(store, []() { return Result<std::monostate, Trap>(std::monostate()); });
+  assert_func_type(f.type(store), {}, {});
+  f = Func::wrap(store, []() { return Result<int32_t, Trap>(1); });
+  assert_func_type(f.type(store), {}, {ValKind::I32});
+  f = Func::wrap(store, []() { return Result<float, Trap>(1); });
+  assert_func_type(f.type(store), {}, {ValKind::F32});
+  f = Func::wrap(store, []() { return Result<std::tuple<int32_t, int32_t>, Trap>({1, 2}); });
+  assert_func_type(f.type(store), {}, {ValKind::I32, ValKind::I32});
+
+  f = Func::wrap(store, [](int32_t a) {});
+  assert_func_type(f.type(store), {ValKind::I32}, {});
+  f = Func::wrap(store, [](int64_t a) {});
+  assert_func_type(f.type(store), {ValKind::I64}, {});
+  f = Func::wrap(store, [](float a) {});
+  assert_func_type(f.type(store), {ValKind::F32}, {});
+  f = Func::wrap(store, [](double a) {});
+  assert_func_type(f.type(store), {ValKind::F64}, {});
+  f = Func::wrap(store, [](V128 a) {});
+  assert_func_type(f.type(store), {ValKind::V128}, {});
+  f = Func::wrap(store, [](std::optional<Func> a) {});
+  assert_func_type(f.type(store), {ValKind::FuncRef}, {});
+  f = Func::wrap(store, [](std::optional<ExternRef> a) {});
+  assert_func_type(f.type(store), {ValKind::ExternRef}, {});
+  f = Func::wrap(store, [](Caller a) {});
+  assert_func_type(f.type(store), {}, {});
+  f = Func::wrap(store, [](Caller a, int32_t b) {});
+  assert_func_type(f.type(store), {ValKind::I32}, {});
+}
+
+TEST(TypedFunc, WrapRuntime) {
+  Engine engine;
+  Store store(engine);
+  Func f = Func::wrap(store, []() {});
+  f.typed<empty_t, empty_t>(store).unwrap().call(store, empty_t()).unwrap();
+
+  f = Func::wrap(store, []() { return int32_t(1); });
+  int32_t i = f.typed<empty_t, int32_t>(store).unwrap().call(store, empty_t()).unwrap();
+  EXPECT_EQ(i, 1);
+
+  f = Func::wrap(store, [](Caller cx, int32_t i) {
+    EXPECT_EQ(i, 2);
+  });
+  f.typed<int32_t, empty_t>(store).unwrap().call(store, 2).unwrap();
+
+  f = Func::wrap(store, [](Caller cx, int32_t i, int32_t j) {
+    return i + j;
+  });
+  auto ret = f.typed<std::tuple<int32_t, int32_t>, int32_t>(store).unwrap().call(store, {1, 2}).unwrap();
+  EXPECT_EQ(ret, 3);
+}


### PR DESCRIPTION
This commit binds two new APIs added to `wasmtime`'s C API recently:

* `wasmtime_func_new_unchecked`
* `wamstime_func_call_unchecked`

These two functions are a more accelerated path of invoking a
WebAssembly function and having a WebAssembly function call the host.
The new APIs are generally unsafe but with the C++ bindings added here
they should at least be type-safe. The goal was to add APIs similar to
the Rust crate's `Func::wrap` and `Func::typed` for statically-typed
function calls.

Overall the performance here worked out great in that it's on-par with C
and as expected from the PR adding the `*_unchecked` variants. This is,
however, basically my first foray into templated functions in C++ and
wow is this a lot more complicated than I thought that it would be. Some
extra eyes on this would be appreciated to see if I've missed something
or if the design could be simplified.