### PR TITLE
Use `<iosfwd>` instead of `<iostream>`

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -35,7 +35,7 @@
 #include <any>
 #include <array>
 #include <initializer_list>
-#include <iostream>
+#include <iosfwd>
 #include <limits>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
Looks like this header is intended to compile much faster and bring in
less bloat, and there's no other reason to bring in `<iostream>` so use
`<iosfwd>` instead.

Closes #18