### PR TITLE
Add Module::deserialize_file() to expose wasm_module_deserialize_file()

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -2257,7 +2257,7 @@ template <typename... T> struct WasmTypeList<std::tuple<T...>> {
                     const std::tuple<T...> &t) {
     size_t n = 0;
     std::apply(
-        [&](const auto &... val) {
+        [&](const auto &...val) {
           (WasmType<T>::store(cx, &storage[n++], val), ...); // NOLINT
         },
         t);
@@ -2329,7 +2329,7 @@ template <typename R, typename... A> struct WasmHostFunc<R (*)(A...)> {
   static std::optional<Trap> invoke(F &f, Caller cx, wasmtime_val_raw_t *raw) {
     auto params = Params::load(cx, raw);
     return std::apply(
-        [&](const auto &... val) {
+        [&](const auto &...val) {
           return WasmHostRet<R>::invoke(f, cx, raw, val...);
         },
         params);
@@ -2344,7 +2344,7 @@ struct WasmHostFunc<R (*)(Caller, A...)> : public WasmHostFunc<R (*)(A...)> {
   static std::optional<Trap> invoke(F &f, Caller cx, wasmtime_val_raw_t *raw) {
     auto params = WasmTypeList<std::tuple<A...>>::load(cx, raw);
     return std::apply(
-        [&](const auto &... val) {
+        [&](const auto &...val) {
           return WasmHostRet<R>::invoke(f, cx, raw, cx, val...);
         },
         params);

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -1550,6 +1550,31 @@ public:
     return Module(ret);
   }
 
+  /**
+   * \brief Deserializes a module from an on-disk file.
+   *
+   * This function is the same as wasmtime_module_deserialize except that it
+   * reads the data for the serialized module from the path on disk. This can
+   * be faster than the alternative which may require copying the data around.
+   * the artifacts of a previous compilation to quickly create an in-memory
+   * module ready for instantiation.
+   *
+   * It is not safe to pass arbitrary input to this function, it is only safe to
+   * pass in output from previous calls to `serialize`. For more information see
+   * the Rust documentation -
+   * https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.deserialize
+   */
+  [[nodiscard]] static Result<Module> deserialize_file(Engine &engine,
+						       const std::string &path) {
+    wasmtime_module_t *ret = nullptr;
+    auto *error = wasmtime_module_deserialize_file(engine.ptr.get(),
+						   path.c_str(), &ret);
+    if (error != nullptr) {
+      return Error(error);
+    }
+    return Module(ret);
+  }
+
   /// Returns the type of this module, which can be used to inspect the
   /// imports/exports.
   ModuleType type() { return wasmtime_module_type(ptr.get()); }

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -1564,11 +1564,11 @@ public:
    * the Rust documentation -
    * https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.deserialize
    */
-  [[nodiscard]] static Result<Module> deserialize_file(Engine &engine,
-						       const std::string &path) {
+  [[nodiscard]] static Result<Module>
+  deserialize_file(Engine &engine, const std::string &path) {
     wasmtime_module_t *ret = nullptr;
-    auto *error = wasmtime_module_deserialize_file(engine.ptr.get(),
-						   path.c_str(), &ret);
+    auto *error =
+        wasmtime_module_deserialize_file(engine.ptr.get(), path.c_str(), &ret);
     if (error != nullptr) {
       return Error(error);
     }
@@ -2257,7 +2257,7 @@ template <typename... T> struct WasmTypeList<std::tuple<T...>> {
                     const std::tuple<T...> &t) {
     size_t n = 0;
     std::apply(
-        [&](const auto &...val) {
+        [&](const auto &... val) {
           (WasmType<T>::store(cx, &storage[n++], val), ...); // NOLINT
         },
         t);
@@ -2329,7 +2329,7 @@ template <typename R, typename... A> struct WasmHostFunc<R (*)(A...)> {
   static std::optional<Trap> invoke(F &f, Caller cx, wasmtime_val_raw_t *raw) {
     auto params = Params::load(cx, raw);
     return std::apply(
-        [&](const auto &...val) {
+        [&](const auto &... val) {
           return WasmHostRet<R>::invoke(f, cx, raw, val...);
         },
         params);
@@ -2344,7 +2344,7 @@ struct WasmHostFunc<R (*)(Caller, A...)> : public WasmHostFunc<R (*)(A...)> {
   static std::optional<Trap> invoke(F &f, Caller cx, wasmtime_val_raw_t *raw) {
     auto params = WasmTypeList<std::tuple<A...>>::load(cx, raw);
     return std::apply(
-        [&](const auto &...val) {
+        [&](const auto &... val) {
           return WasmHostRet<R>::invoke(f, cx, raw, cx, val...);
         },
         params);

--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -116,7 +116,7 @@ TEST(Module, Serialize) {
   auto bytes = unwrap(m.serialize());
   m = unwrap(Module::deserialize(engine, bytes));
   std::string path("tmp.cwasm");
-  std::ofstream fs(path);
+  std::ofstream fs(path, std::ios::out | std::ios::binary);
   std::copy(bytes.begin(), bytes.end(), std::ostreambuf_iterator<char>(fs));
   fs.close();
   m = unwrap(Module::deserialize_file(engine, path));

--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -1,3 +1,4 @@
+#include <fstream>
 #include <gtest/gtest.h>
 #include <wasmtime.hh>
 
@@ -114,6 +115,12 @@ TEST(Module, Serialize) {
   Module m = unwrap(Module::compile(engine, "(module)"));
   auto bytes = unwrap(m.serialize());
   m = unwrap(Module::deserialize(engine, bytes));
+  std::string path("tmp.cwasm");
+  std::ofstream fs(path);
+  std::copy(bytes.begin(), bytes.end(), std::ostreambuf_iterator<char>(fs));
+  fs.close();
+  m = unwrap(Module::deserialize_file(engine, path));
+  ::remove(path.c_str());
 }
 
 TEST(WasiConfig, Smoke) {


### PR DESCRIPTION
Exposes the C API wasm_module_deserialize_file() functionality for more performant module loading.