### PR TITLE
Don't use `std::cerr` in header

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -183,7 +183,7 @@ public:
 
 private:
   [[noreturn]] void unwrap_failed() {
-    fprintf(stderr, "error: %s\n", this->err().message().c_str());
+    fprintf(stderr, "error: %s\n", this->err().message().c_str()); // NOLINT
     std::abort();
   }
 };

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -36,6 +36,7 @@
 #include <array>
 #include <initializer_list>
 #include <iosfwd>
+#include <cstdio>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -133,7 +134,7 @@ public:
   Error(std::string_view msg) : msg(msg) {}
 
   /// \brief Returns the error message associated with this error.
-  std::string_view message() const { return msg; }
+  const std::string& message() const { return msg; }
 };
 
 /// \brief Used to print an error.
@@ -177,12 +178,12 @@ public:
     if (*this) {
       return this->ok();
     }
-    abort();
+    unwrap_failed();
   }
 
 private:
-  [[noreturn]] void abort() {
-    std::cerr << "error: " << this->err().message() << "\n";
+  [[noreturn]] void unwrap_failed() {
+    fprintf(stderr, "error: %s\n", this->err().message().c_str());
     std::abort();
   }
 };

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -34,9 +34,9 @@
 
 #include <any>
 #include <array>
+#include <cstdio>
 #include <initializer_list>
 #include <iosfwd>
-#include <cstdio>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -134,7 +134,7 @@ public:
   Error(std::string_view msg) : msg(msg) {}
 
   /// \brief Returns the error message associated with this error.
-  const std::string& message() const { return msg; }
+  const std::string &message() const { return msg; }
 };
 
 /// \brief Used to print an error.


### PR DESCRIPTION
Looks like this isn't always defined and the necessary functionality can
be done with `fprintf` instead.

cc #18