### PR TITLE
Minor updates

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -1553,9 +1553,9 @@ public:
   /**
    * \brief Deserializes a module from an on-disk file.
    *
-   * This function is the same as `deserialize` except that it reads the data for
-   * the serialized module from the path on disk. This can be faster than the
-   * alternative which may require copying the data around.
+   * This function is the same as `deserialize` except that it reads the data
+   * for the serialized module from the path on disk. This can be faster than
+   * the alternative which may require copying the data around.
    *
    * It is not safe to pass arbitrary input to this function, it is only safe to
    * pass in output from previous calls to `serialize`. For more information see

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -1553,12 +1553,9 @@ public:
   /**
    * \brief Deserializes a module from an on-disk file.
    *
-   * This function is the same as wasmtime_module_deserialize except that it
-   * reads the data for the serialized module from the path on disk. This can
-   * be faster than the alternative which may require copying the data around.
-   *
-   * This function does not take ownership of any of its arguments, but the
-   * returned error and module are owned by the caller.
+   * This function is the same as `deserialize` except that it reads the data for
+   * the serialized module from the path on disk. This can be faster than the
+   * alternative which may require copying the data around.
    *
    * It is not safe to pass arbitrary input to this function, it is only safe to
    * pass in output from previous calls to `serialize`. For more information see

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -1556,8 +1556,9 @@ public:
    * This function is the same as wasmtime_module_deserialize except that it
    * reads the data for the serialized module from the path on disk. This can
    * be faster than the alternative which may require copying the data around.
-   * the artifacts of a previous compilation to quickly create an in-memory
-   * module ready for instantiation.
+   *
+   * This function does not take ownership of any of its arguments, but the
+   * returned error and module are owned by the caller.
    *
    * It is not safe to pass arbitrary input to this function, it is only safe to
    * pass in output from previous calls to `serialize`. For more information see

--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -1,4 +1,3 @@
-#include <fstream>
 #include <gtest/gtest.h>
 #include <wasmtime.hh>
 
@@ -115,10 +114,10 @@ TEST(Module, Serialize) {
   Module m = unwrap(Module::compile(engine, "(module)"));
   auto bytes = unwrap(m.serialize());
   m = unwrap(Module::deserialize(engine, bytes));
-  std::string path("tmp.cwasm");
-  std::ofstream fs(path, std::ios::out | std::ios::binary);
-  std::copy(bytes.begin(), bytes.end(), std::ostreambuf_iterator<char>(fs));
-  fs.close();
+  std::string path("test_deserialize_file.cwasm");
+  auto fh = ::fopen(path.c_str(), "w");
+  ::fwrite(bytes.data(), sizeof(uint8_t), bytes.size(), fh);
+  ::fclose(fh);
   m = unwrap(Module::deserialize_file(engine, path));
   ::remove(path.c_str());
 }

--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -115,7 +115,7 @@ TEST(Module, Serialize) {
   auto bytes = unwrap(m.serialize());
   m = unwrap(Module::deserialize(engine, bytes));
   std::string path("test_deserialize_file.cwasm");
-  auto fh = ::fopen(path.c_str(), "w");
+  auto fh = ::fopen(path.c_str(), "wb");
   ::fwrite(bytes.data(), sizeof(uint8_t), bytes.size(), fh);
   ::fclose(fh);
   m = unwrap(Module::deserialize_file(engine, path));


### PR DESCRIPTION
Fixes a small copy/paste error in deserialize_file() comment.

Update the deserialize_file() test to use FILE* instead of ofstream to avoid the fstream dependency if not needed.