### PR TITLE
Fix library feature test for std::span

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -42,8 +42,10 @@
 #include <optional>
 #include <variant>
 #include <vector>
-#ifdef __cpp_lib_span
+#ifdef __has_include
+#if __has_include(<span>)
 #include <span>
+#endif
 #endif
 
 #include "wasmtime.h"


### PR DESCRIPTION
Hello :)
`__cpp_lib_span` is only defined when `<version>` or `<span>` is included, so `std::span` could never be used as an alias for `Span`, see https://en.cppreference.com/w/cpp/utility/feature_test.
Now, `<span>` is included as recommended here:
https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html.
Afterwards, `__cpp_lib_span` is properly defined.

I noticed this, because I have `std::span` and wanted to use `subspan` which is not available on `wasmtime::Span`.
The following test file only compiles with this patch, showing that `Span` is not an alias for `std::span`:
```cpp
#include "wasmtime.hh"
using namespace wasmtime;
#include <span>
auto foo(std::span<uint8_t>) {}
int main() {
  Engine engine;
  Store store(engine);
  MemoryType ty(5, 5);
  Memory memory = Memory::create(store, ty).unwrap();
  foo(memory.data(store));
}
```