### PR TITLE
Add an X macro for `ValKind` processing

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -476,7 +476,7 @@ enum class ValKind {
 
 /// Helper X macro to construct statement for each enumerator in `ValKind`.
 /// X(enumerator in `ValKind`, name string, enumerator in `wasm_valkind_t`)
-#define WASMTIME_FOR_EACH_VAL_KIND                                             \
+#define WASMTIME_FOR_EACH_VAL_KIND(X)                                          \
   X(I32, "i32", WASM_I32)                                                      \
   X(I64, "i64", WASM_I64)                                                      \
   X(F32, "f32", WASM_F32)                                                      \
@@ -488,12 +488,12 @@ enum class ValKind {
 /// \brief Used to print a ValKind.
 inline std::ostream &operator<<(std::ostream &os, const ValKind &e) {
   switch (e) {
-#define X(kind, name, ignore)                                                  \
+#define CASE_KIND_PRINT_NAME(kind, name, ignore)                               \
   case ValKind::kind:                                                          \
     os << name;                                                                \
     break;
-    WASMTIME_FOR_EACH_VAL_KIND
-#undef X
+    WASMTIME_FOR_EACH_VAL_KIND(CASE_KIND_PRINT_NAME)
+#undef CASE_KIND_PRINT_NAME
   default:
     abort();
   }
@@ -518,11 +518,11 @@ class ValType {
 
   static wasm_valkind_t kind_to_c(ValKind kind) {
     switch (kind) {
-#define X(kind, ignore, ckind)                                                 \
+#define CASE_KIND_TO_C(kind, ignore, ckind)                                    \
   case ValKind::kind:                                                          \
     return ckind;
-      WASMTIME_FOR_EACH_VAL_KIND
-#undef X
+      WASMTIME_FOR_EACH_VAL_KIND(CASE_KIND_TO_C)
+#undef CASE_KIND_TO_C
     default:
       abort();
     }
@@ -545,11 +545,11 @@ public:
     /// \brief Returns the corresponding "kind" for this type.
     ValKind kind() const {
       switch (wasm_valtype_kind(ptr)) {
-#define X(kind, ignore, ckind)                                                 \
+#define CASE_C_TO_KIND(kind, ignore, ckind)                                    \
   case ckind:                                                                  \
     return ValKind::kind;
-        WASMTIME_FOR_EACH_VAL_KIND
-#undef X
+        WASMTIME_FOR_EACH_VAL_KIND(CASE_C_TO_KIND)
+#undef CASE_C_TO_KIND
       }
       std::abort();
     }

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -1912,11 +1912,20 @@ public:
   /// Returns the kind of value that this value has.
   ValKind kind() const {
     switch (val.kind) {
-#define X(kind, ignore, ckind)                                                 \
-  case ckind:                                                                  \
-    return ValKind::kind;
-      FOR_EACH_VAL_KIND
-#undef X
+    case WASMTIME_I32:
+      return ValKind::I32;
+    case WASMTIME_I64:
+      return ValKind::I64;
+    case WASMTIME_F32:
+      return ValKind::F32;
+    case WASMTIME_F64:
+      return ValKind::F64;
+    case WASMTIME_FUNCREF:
+      return ValKind::FuncRef;
+    case WASMTIME_EXTERNREF:
+      return ValKind::ExternRef;
+    case WASMTIME_V128:
+      return ValKind::V128;
     }
     std::abort();
   }

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -476,7 +476,7 @@ enum class ValKind {
 
 /// Helper X macro to construct statement for each enumerator in `ValKind`.
 /// X(enumerator in `ValKind`, name string, enumerator in `wasm_valkind_t`)
-#define FOR_EACH_VAL_KIND                                                      \
+#define WASMTIME_FOR_EACH_VAL_KIND                                             \
   X(I32, "i32", WASM_I32)                                                      \
   X(I64, "i64", WASM_I64)                                                      \
   X(F32, "f32", WASM_F32)                                                      \
@@ -492,7 +492,7 @@ inline std::ostream &operator<<(std::ostream &os, const ValKind &e) {
   case ValKind::kind:                                                          \
     os << name;                                                                \
     break;
-    FOR_EACH_VAL_KIND
+    WASMTIME_FOR_EACH_VAL_KIND
 #undef X
   default:
     abort();
@@ -521,7 +521,7 @@ class ValType {
 #define X(kind, ignore, ckind)                                                 \
   case ValKind::kind:                                                          \
     return ckind;
-      FOR_EACH_VAL_KIND
+      WASMTIME_FOR_EACH_VAL_KIND
 #undef X
     default:
       abort();
@@ -548,7 +548,7 @@ public:
 #define X(kind, ignore, ckind)                                                 \
   case ckind:                                                                  \
     return ValKind::kind;
-        FOR_EACH_VAL_KIND
+        WASMTIME_FOR_EACH_VAL_KIND
 #undef X
       }
       std::abort();

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -474,30 +474,26 @@ enum class ValKind {
   FuncRef,
 };
 
+/// Helper X macro to construct statement for each enumerator in `ValKind`.
+/// X(enumerator in `ValKind`, name string, enumerator in `wasm_valkind_t`)
+#define FOR_EACH_VAL_KIND                                                      \
+  X(I32, "i32", WASM_I32)                                                      \
+  X(I64, "i64", WASM_I64)                                                      \
+  X(F32, "f32", WASM_F32)                                                      \
+  X(F64, "f64", WASM_F64)                                                      \
+  X(ExternRef, "externref", WASM_ANYREF)                                       \
+  X(FuncRef, "funcref", WASM_FUNCREF)                                          \
+  X(V128, "v128", WASMTIME_V128)
+
 /// \brief Used to print a ValKind.
 inline std::ostream &operator<<(std::ostream &os, const ValKind &e) {
   switch (e) {
-  case ValKind::I32:
-    os << "i32";
+#define X(kind, name, ignore)                                                  \
+  case ValKind::kind:                                                          \
+    os << name;                                                                \
     break;
-  case ValKind::I64:
-    os << "i64";
-    break;
-  case ValKind::F32:
-    os << "f32";
-    break;
-  case ValKind::F64:
-    os << "f64";
-    break;
-  case ValKind::ExternRef:
-    os << "externref";
-    break;
-  case ValKind::FuncRef:
-    os << "funcref";
-    break;
-  case ValKind::V128:
-    os << "v128";
-    break;
+    FOR_EACH_VAL_KIND
+#undef X
   default:
     abort();
   }
@@ -522,20 +518,11 @@ class ValType {
 
   static wasm_valkind_t kind_to_c(ValKind kind) {
     switch (kind) {
-    case ValKind::I32:
-      return WASM_I32;
-    case ValKind::I64:
-      return WASM_I64;
-    case ValKind::F32:
-      return WASM_F32;
-    case ValKind::F64:
-      return WASM_F64;
-    case ValKind::ExternRef:
-      return WASM_ANYREF;
-    case ValKind::FuncRef:
-      return WASM_FUNCREF;
-    case ValKind::V128:
-      return WASMTIME_V128;
+#define X(kind, ignore, ckind)                                                 \
+  case ValKind::kind:                                                          \
+    return ckind;
+      FOR_EACH_VAL_KIND
+#undef X
     default:
       abort();
     }
@@ -558,20 +545,11 @@ public:
     /// \brief Returns the corresponding "kind" for this type.
     ValKind kind() const {
       switch (wasm_valtype_kind(ptr)) {
-      case WASM_I32:
-        return ValKind::I32;
-      case WASM_I64:
-        return ValKind::I64;
-      case WASM_F32:
-        return ValKind::F32;
-      case WASM_F64:
-        return ValKind::F64;
-      case WASM_ANYREF:
-        return ValKind::ExternRef;
-      case WASM_FUNCREF:
-        return ValKind::FuncRef;
-      case WASMTIME_V128:
-        return ValKind::V128;
+#define X(kind, ignore, ckind)                                                 \
+  case ckind:                                                                  \
+    return ValKind::kind;
+        FOR_EACH_VAL_KIND
+#undef X
       }
       std::abort();
     }
@@ -1934,20 +1912,11 @@ public:
   /// Returns the kind of value that this value has.
   ValKind kind() const {
     switch (val.kind) {
-    case WASMTIME_I32:
-      return ValKind::I32;
-    case WASMTIME_I64:
-      return ValKind::I64;
-    case WASMTIME_F32:
-      return ValKind::F32;
-    case WASMTIME_F64:
-      return ValKind::F64;
-    case WASMTIME_FUNCREF:
-      return ValKind::FuncRef;
-    case WASMTIME_EXTERNREF:
-      return ValKind::ExternRef;
-    case WASMTIME_V128:
-      return ValKind::V128;
+#define X(kind, ignore, ckind)                                                 \
+  case ckind:                                                                  \
+    return ValKind::kind;
+      FOR_EACH_VAL_KIND
+#undef X
     }
     std::abort();
   }


### PR DESCRIPTION
In the previous code, there are repeated instances of `switch` `case` code related to `ValKind`, which makes the code redundant and difficult to maintain. 

In this PR, I have created an X macro `WASMTIME_FOR_EACH_VAL_KIND` to store this information centrally and expand it during processing.


About X macro: https://en.wikipedia.org/wiki/X_macro