### PR TITLE
Make container ctor of Span more general

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -89,9 +89,17 @@ public:
   Span(T *t, std::size_t n) : ptr_{t}, size_{n} {}
 
   /// \brief Constructor of Span class for containers
-  template <typename C, std::enable_if_t<!IsSpan<C>::value, int> = 0,
-            std::void_t<decltype(std::declval<C>().data()),
-                        decltype(std::declval<C>().size())> * = nullptr>
+  template <typename C,
+            std::enable_if_t<
+                !IsSpan<C>::value &&
+                    std::is_pointer_v<decltype(std::declval<C &>().data())> &&
+                    std::is_convertible_v<
+                        std::remove_pointer_t<
+                            decltype(std::declval<C &>().data())> (*)[],
+                        T (*)[]> &&
+                    std::is_convertible_v<decltype(std::declval<C>().size()),
+                                          std::size_t>,
+                int> = 0>
   Span(C &range) : ptr_{range.data()}, size_{range.size()} {}
 
   /// \brief Returns item by index


### PR DESCRIPTION
The current constructor of `Span` which accepts a container (attached below) is not general enough.
```c++
  template <template <typename, typename> class Container>
  Span(Container<T, std::allocator<T>> &range)
```
The argument can only be a class with two template arguments and the second argument must be `std::allocator<T>`.
But actually a *container* in C++ can be [any type that satisfy certain constraints](https://en.cppreference.com/w/cpp/named_req/Container).
Here, we can just accept a type which is *not a `Span`* and *has method `data` and `size`*.

Besides, the implementation is wrong when the template argument `Extent` is not `dynamic_extent` (the `Extent` will just be ignored in this implementation), so I think we can just prevent the instantiation to prevent mis-understanding.
