### PR TITLE
Update for removal of externref from C API

### DIFF
--- a/examples/externref.cc
+++ b/examples/externref.cc
@@ -14,6 +14,7 @@ std::string readFile(const char* name) {
 }
 
 int main() {
+#if WASMTIME_HAS_EXTERNREF
   std::cout << "Initializing...\n";
   Engine engine;
   Store store(engine);
@@ -49,4 +50,7 @@ int main() {
 
   std::cout << "Running a gc..\n";
   store.context().gc();
+#else
+  std::cout << "no support for externref at compile time\n";
+#endif
 }

--- a/tests/func.cc
+++ b/tests/func.cc
@@ -71,6 +71,7 @@ TEST(TypedFunc, Call) {
     EXPECT_EQ(std::get<1>(result), 4);
   }
 
+#if WASMTIME_HAS_EXTERNREF
   {
     FuncType ty({ValKind::ExternRef, ValKind::ExternRef}, {ValKind::ExternRef, ValKind::ExternRef});
     Func f(store, ty, [](auto caller, auto params, auto results) {
@@ -91,6 +92,7 @@ TEST(TypedFunc, Call) {
     EXPECT_EQ(std::any_cast<int>(std::get<0>(result)->data()), 3);
     EXPECT_EQ(std::get<1>(result), std::nullopt);
   }
+#endif
 
   {
     Func f2(store, FuncType({}, {}), [](auto caller, auto params, auto results) {
@@ -178,8 +180,10 @@ TEST(TypedFunc, WrapAndTypes) {
   assert_func_type(f.type(store), {}, {ValKind::I32, ValKind::I32});
   f = Func::wrap(store, []() { return std::optional<Func>(std::nullopt); });
   assert_func_type(f.type(store), {}, {ValKind::FuncRef});
+#if WASMTIME_HAS_EXTERNREF
   f = Func::wrap(store, []() { return std::optional<ExternRef>(std::nullopt); });
   assert_func_type(f.type(store), {}, {ValKind::ExternRef});
+#endif
   f = Func::wrap(store, []() { return Result<std::monostate, Trap>(std::monostate()); });
   assert_func_type(f.type(store), {}, {});
   f = Func::wrap(store, []() { return Result<int32_t, Trap>(1); });
@@ -201,8 +205,10 @@ TEST(TypedFunc, WrapAndTypes) {
   assert_func_type(f.type(store), {ValKind::V128}, {});
   f = Func::wrap(store, [](std::optional<Func> a) {});
   assert_func_type(f.type(store), {ValKind::FuncRef}, {});
+#if WASMTIME_HAS_EXTERNREF
   f = Func::wrap(store, [](std::optional<ExternRef> a) {});
   assert_func_type(f.type(store), {ValKind::ExternRef}, {});
+#endif
   f = Func::wrap(store, [](Caller a) {});
   assert_func_type(f.type(store), {}, {});
   f = Func::wrap(store, [](Caller a, int32_t b) {});

--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -20,7 +20,9 @@ TEST(Store, Smoke) {
 
   store = Store(engine);
   store.limiter(-1, -1, -1, -1, -1);
+#if WASMTIME_HAS_EXTERNREF
   store.context().gc();
+#endif
   store.context().get_fuel().err();
   store.context().set_fuel(1).err();
   store.context().set_epoch_deadline(1);
@@ -136,6 +138,7 @@ TEST(WasiConfig, Smoke) {
   EXPECT_FALSE(config.preopen_dir("nonexistent", "nonexistent"));
 }
 
+#if WASMTIME_HAS_EXTERNREF
 TEST(ExternRef, Smoke) {
   ExternRef a("foo");
   ExternRef b(3);
@@ -143,6 +146,7 @@ TEST(ExternRef, Smoke) {
   EXPECT_EQ(std::any_cast<int>(b.data()), 3);
   a = b;
 }
+#endif
 
 TEST(Val, Smoke) {
   Val val(1);
@@ -171,6 +175,7 @@ TEST(Val, Smoke) {
     EXPECT_EQ(val.v128().v128[i], 0);
   }
 
+#if WASMTIME_HAS_EXTERNREF
   val = std::optional<ExternRef>(std::nullopt);
   EXPECT_EQ(val.kind(), ValKind::ExternRef);
   EXPECT_EQ(val.externref(), std::nullopt);
@@ -182,6 +187,7 @@ TEST(Val, Smoke) {
   val = ExternRef(5);
   EXPECT_EQ(val.kind(), ValKind::ExternRef);
   EXPECT_EQ(std::any_cast<int>(val.externref()->data()), 5);
+#endif
 
   val = std::optional<Func>(std::nullopt);
   EXPECT_EQ(val.kind(), ValKind::FuncRef);
@@ -198,9 +204,6 @@ TEST(Val, Smoke) {
 
   val = func;
   EXPECT_EQ(val.kind(), ValKind::FuncRef);
-
-  Val other(1);
-  val = other;
 }
 
 TEST(Global, Smoke) {

--- a/tests/types.cc
+++ b/tests/types.cc
@@ -19,7 +19,9 @@ TEST(ValType, Smoke) {
   EXPECT_EQ(ValType(ValKind::F64)->kind(), ValKind::F64);
   EXPECT_EQ(ValType(ValKind::V128)->kind(), ValKind::V128);
   EXPECT_EQ(ValType(ValKind::FuncRef)->kind(), ValKind::FuncRef);
+#if WASMTIME_HAS_EXTERNREF
   EXPECT_EQ(ValType(ValKind::ExternRef)->kind(), ValKind::ExternRef);
+#endif
 
   ValType t(ValKind::I32);
   t = ValKind::I64;


### PR DESCRIPTION
Also update some utilities on `Val` which can no longer be implemented without a store parameter.