### PR TITLE
Include iostream in wasmtime.hh

### DIFF
--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -37,6 +37,7 @@
 #include <cstdio>
 #include <initializer_list>
 #include <iosfwd>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
The examples will fail if `iostream` is not included. Therefore, I added and PR'ed it.