### PR TITLE
Added Missing Include: ostream

### DIFF
--- a/examples/hello.cc
+++ b/examples/hello.cc
@@ -1,7 +1,7 @@
+#include <wasmtime.hh>
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <wasmtime.hh>
 
 using namespace wasmtime;
 

--- a/include/wasmtime.hh
+++ b/include/wasmtime.hh
@@ -40,6 +40,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <variant>
 #include <vector>
 #ifdef __has_include


### PR DESCRIPTION
The ValKind::operator<< uses ostream, but the include was missing. ostream is used so commonly that it's usually included by some other header. However, if you use wasmtime.hh as your first (or only) include, then you get a massive compile error on Apple toolchain compilers (I'm using xcode 16). The error does not reproduce on Linux.

The error when this include is missing is:
```
include/wasmtime.hh:519:32: error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'const char[4]')
  519 |     WASMTIME_FOR_EACH_VAL_KIND(CASE_KIND_PRINT_NAME)
include/wasmtime.hh:504:3: note: expanded from macro 'WASMTIME_FOR_EACH_VAL_KIND'
  504 |   X(I32, "i32", WASM_I32)                                                      \
      |   ^~~~~~~~~~~~~~~~~~~~~~~
include/wasmtime.hh:517:8: note: expanded from macro 'CASE_KIND_PRINT_NAME'
  517 |     os << name;                                                                \
```