### PR TITLE
Adjusting the function passed to func_new/func_wrap to be universal reference so that we can perfectly forward it on.

### DIFF
--- a/tests/simple.cc
+++ b/tests/simple.cc
@@ -329,6 +329,46 @@ TEST(Linker, Smoke) {
   EXPECT_TRUE(std::holds_alternative<Func>(*linker.get(store, "a", "f")));
 }
 
+TEST(Linker, CallableMove) {
+  Engine engine;
+  Linker linker(engine);
+  Store store(engine);
+  linker.allow_shadowing(false);
+
+  struct CallableFunc {
+    CallableFunc() = default;
+    CallableFunc(const CallableFunc&) = delete;
+    CallableFunc(CallableFunc&&) = default;
+
+    Result<std::monostate, Trap> operator()(Caller caller, Span<const Val> params, Span<Val> results) {
+      return std::monostate();
+    }
+  };
+
+  CallableFunc cf;
+  unwrap(linker.func_new("a", "f", FuncType({}, {}), std::move(cf)));
+}
+
+TEST(Linker, CallableCopy) {
+  Engine engine;
+  Linker linker(engine);
+  Store store(engine);
+  linker.allow_shadowing(false);
+
+  struct CallableFunc {
+    CallableFunc() = default;
+    CallableFunc(const CallableFunc&) = default;
+    CallableFunc(CallableFunc&&) = default;
+
+    Result<std::monostate, Trap> operator()(Caller caller, Span<const Val> params, Span<Val> results) {
+      return std::monostate();
+    }
+  };
+
+  CallableFunc cf;
+  unwrap(linker.func_new("a", "f", FuncType({}, {}), cf));
+}
+
 TEST(Caller, Smoke) {
   Engine engine;
   Store store(engine);


### PR DESCRIPTION
Adjusting the function passed to func_new/func_wrap to be universal reference so that we can perfectly forward it on.

The issue, as shown by the test cases, is that previously the function was always copied when passed to func_new/wrap. This works fine for pointers, but when using a callable (like a lambda) it's unnecessarily copied. Furthermore, for callables which aren't allowed to be copied compilation actually fails.

The fix is to move the callable when the callable is passed in as an xvalue.

Tests failing before these changes: https://github.com/bytecodealliance/wasmtime-cpp/actions/runs/12304195157?pr=62
Error:
```
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:1065:34: error: call to deleted constructor of 'CallableFunc'
    { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
                                 ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/wasmtime-cpp/wasmtime-cpp/include/wasmtime.hh:3094:51: note: in instantiation of function template specialization 'std::make_unique<CallableFunc, CallableFunc &>' requested here
        ty.ptr.get(), Func::raw_callback<F>, std::make_unique<F>(f).release(),
```